### PR TITLE
Add local app preferences for theme and notifications

### DIFF
--- a/lib/app/app.dart
+++ b/lib/app/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_frontend/core/services/app_preferences_service.dart';
 import '../core/theme/app_theme.dart';
 import '../core/telemetry/screen_time_observer.dart';
 import 'routes.dart';
@@ -14,12 +15,16 @@ class App extends StatefulWidget {
 }
 
 class _AppState extends State<App> {
+  late final AppPreferencesService _appPreferencesService;
   late final ThemeController _themeController;
 
   @override
   void initState() {
     super.initState();
-    _themeController = ThemeController();
+    _appPreferencesService = AppPreferencesService();
+    _themeController = ThemeController(
+      preferencesService: _appPreferencesService,
+    );
     _themeController.initialize();
   }
 

--- a/lib/app/theme_controller.dart
+++ b/lib/app/theme_controller.dart
@@ -2,22 +2,23 @@ import 'dart:async';
 
 import 'package:ambient_light/ambient_light.dart';
 import 'package:flutter/material.dart';
-import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_frontend/core/services/app_preferences_service.dart';
 
 enum AppThemePreference { light, dark, schedule, sensor }
 
 enum ThemeSource { manual, ambientLight, schedule }
 
 class ThemeController extends ChangeNotifier {
-  static const String _themePreferenceKey = 'theme_preference';
   static const double _darkLuxThreshold = 18;
   static const double _lightLuxThreshold = 180;
   static const Duration _sensorPollingInterval = Duration(seconds: 4);
   static const int _requiredStableSensorReadings = 3;
 
-  ThemeController();
+  ThemeController({AppPreferencesService? preferencesService})
+    : _preferencesService = preferencesService ?? AppPreferencesService();
 
   final AmbientLight _ambientLight = AmbientLight();
+  final AppPreferencesService _preferencesService;
 
   bool _isInitialized = false;
   AppThemePreference _preference = AppThemePreference.schedule;
@@ -69,13 +70,9 @@ class ThemeController extends ChangeNotifier {
       return;
     }
 
-    final prefs = await SharedPreferences.getInstance();
-    final storedPreference = prefs.getString(_themePreferenceKey);
+    final storedPreference = await _preferencesService.getThemePreference();
     if (storedPreference != null) {
-      _preference = AppThemePreference.values.firstWhere(
-        (item) => item.name == storedPreference,
-        orElse: () => AppThemePreference.schedule,
-      );
+      _preference = storedPreference;
     }
 
     _isInitialized = true;
@@ -93,8 +90,7 @@ class ThemeController extends ChangeNotifier {
 
   Future<void> setPreference(AppThemePreference preference) async {
     _preference = preference;
-    final prefs = await SharedPreferences.getInstance();
-    await prefs.setString(_themePreferenceKey, preference.name);
+    await _preferencesService.setThemePreference(preference);
 
     notifyListeners();
   }

--- a/lib/core/services/app_preferences_service.dart
+++ b/lib/core/services/app_preferences_service.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_frontend/app/theme_controller.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AppPreferencesService {
+  AppPreferencesService._();
+
+  static final AppPreferencesService _instance = AppPreferencesService._();
+
+  factory AppPreferencesService() => _instance;
+
+  static const String _themePreferenceKey = 'app_preferences.theme_preference';
+  static const String _notificationsEnabledKey =
+      'app_preferences.notifications_enabled';
+
+  Future<AppThemePreference?> getThemePreference() async {
+    final prefs = await SharedPreferences.getInstance();
+    final storedPreference = prefs.getString(_themePreferenceKey);
+    if (storedPreference == null || storedPreference.trim().isEmpty) {
+      return null;
+    }
+
+    return AppThemePreference.values.firstWhere(
+      (item) => item.name == storedPreference,
+      orElse: () => AppThemePreference.schedule,
+    );
+  }
+
+  Future<void> setThemePreference(AppThemePreference value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_themePreferenceKey, value.name);
+  }
+
+  Future<bool> getNotificationsEnabled() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_notificationsEnabledKey) ?? true;
+  }
+
+  Future<void> setNotificationsEnabled(bool value) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_notificationsEnabledKey, value);
+  }
+}

--- a/lib/presentation/pages/profile/profile_page.dart
+++ b/lib/presentation/pages/profile/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:flutter_frontend/core/constants/app_dimensions.dart';
 import 'package:flutter_frontend/core/constants/app_strings.dart';
 import 'package:flutter_frontend/core/models/user_profile.dart';
 import 'package:flutter_frontend/core/network/api_exception.dart';
+import 'package:flutter_frontend/core/services/app_preferences_service.dart';
 import 'package:flutter_frontend/core/services/auth_service.dart';
 import 'package:flutter_frontend/core/services/profile_photo_service.dart';
 import 'package:flutter_frontend/core/services/telemetry_service.dart';
@@ -26,6 +27,7 @@ class ProfilePage extends StatefulWidget {
 }
 
 class _ProfilePageState extends State<ProfilePage> {
+  final AppPreferencesService _preferencesService = AppPreferencesService();
   final AuthService _authService = AuthService();
   final ProfilePhotoService _photoService = ProfilePhotoService();
   final UserService _userService = UserService();
@@ -46,7 +48,20 @@ class _ProfilePageState extends State<ProfilePage> {
   void initState() {
     super.initState();
     _notificationsEnabled = true;
+    _loadPreferences();
     _loadProfile();
+  }
+
+  Future<void> _loadPreferences() async {
+    final notificationsEnabled = await _preferencesService
+        .getNotificationsEnabled();
+    if (!mounted) {
+      return;
+    }
+
+    setState(() {
+      _notificationsEnabled = notificationsEnabled;
+    });
   }
 
   Future<void> _loadProfile() async {
@@ -407,10 +422,11 @@ class _ProfilePageState extends State<ProfilePage> {
     await themeController.setPreference(selected);
   }
 
-  void _handleNotificationsToggle(bool value) {
+  Future<void> _handleNotificationsToggle(bool value) async {
     setState(() {
       _notificationsEnabled = value;
     });
+    await _preferencesService.setNotificationsEnabled(value);
   }
 
   Future<void> _handleSignOut() async {


### PR DESCRIPTION
This PR implements a local storage strategy using SharedPreferences for lightweight app preferences.

## Changes
- Add AppPreferencesService as the single entry point for app preferences
- Move theme persistence out of ThemeController into the new service
- Persist the notifications toggle in ProfilePage
- Keep preferences device-scoped and global to the app

## Why
This fits the local storage use case for small key/value configuration data and keeps persistence logic centralized and easier to maintain.

## Validation
- Theme mode persists after restart
- Notifications toggle persists after restart
- lutter analyze --no-pub passes