### PR TITLE
feat: enforce past date selection for vaccination date

### DIFF
--- a/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
+++ b/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
@@ -423,12 +423,12 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     );
   }
 
-  Future<void> _pickDate() async {
+  Future<void> _pickDate(bool requiredPast) async {
     final pickedDate = await showDatePicker(
       context: context,
       initialDate: DateTime.now(),
       firstDate: DateTime(2000),
-      lastDate: DateTime(2100),
+      lastDate: requiredPast ? DateTime.now() : DateTime(2100),
       builder: _pickerThemeBuilder,
     );
 
@@ -880,7 +880,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
                 }
               });
             },
-            onPickDate: _pickDate,
+            onPickDate: () =>_pickDate(true),
             dateController: _dateController,
           ),
         ];


### PR DESCRIPTION
To ensure the app works in integration with both developement platforms, vaccination are enforced to be picked in the field givenDate a date that is prior from or today.