### PR TITLE
Fix pet detail vaccine status inconsistency

### DIFF
--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -40,7 +40,9 @@ class PetService {
 
   Future<List<PetModel>> getPets({bool forceRefresh = false}) async {
     final cachedEntry = await _cache.get(_petsCacheKey);
-    if (!forceRefresh && cachedEntry != null && cachedEntry.isFresh(_petsCacheTtl)) {
+    if (!forceRefresh &&
+        cachedEntry != null &&
+        cachedEntry.isFresh(_petsCacheTtl)) {
       final cachedPets = _tryParsePets(cachedEntry.body);
       if (cachedPets != null) {
         unawaited(_persistPetsFromBody(cachedEntry.body));
@@ -126,7 +128,10 @@ class PetService {
       }
 
       final localId = _newLocalId('pet');
-      final pendingPayload = _buildPendingPetPayload(source: data, petId: localId);
+      final pendingPayload = _buildPendingPetPayload(
+        source: data,
+        petId: localId,
+      );
 
       await _localDb.upsertEntity(
         table: LocalDbTables.pets,
@@ -254,7 +259,10 @@ class PetService {
       if (response.body.trim().isNotEmpty) {
         final decoded = jsonDecode(response.body);
         if (decoded is Map<String, dynamic>) {
-          await _persistVaccinationMap(_asPetMap(decoded), petId: normalizedPetId);
+          await _persistVaccinationMap(
+            _asPetMap(decoded),
+            petId: normalizedPetId,
+          );
         }
       }
       await _invalidatePetsCache();
@@ -329,6 +337,10 @@ class PetService {
         table: LocalDbTables.petVaccinations,
         remoteId: normalizedVaccinationId,
         payload: merged,
+      );
+      await _upsertVaccinationIntoPetRow(
+        petId: normalizedPetId,
+        vaccinationJson: merged,
       );
       await _invalidatePetsCache();
     } catch (error) {
@@ -431,7 +443,9 @@ class PetService {
       await _persistVaccinationList(maps, petId: normalizedPetId);
       return maps.map(PetVaccinationModel.fromJson).toList(growable: false);
     } catch (_) {
-      final localVaccinations = await _getVaccinationsFromLocalDb(normalizedPetId);
+      final localVaccinations = await _getVaccinationsFromLocalDb(
+        normalizedPetId,
+      );
       if (localVaccinations.isNotEmpty) {
         return localVaccinations;
       }
@@ -490,7 +504,8 @@ class PetService {
       try {
         switch (operation.action) {
           case _actionCreate:
-            final createPayload = operation.payload ?? const <String, dynamic>{};
+            final createPayload =
+                operation.payload ?? const <String, dynamic>{};
             final response = await _apiClient.post(
               petsPath,
               body: jsonEncode(createPayload),
@@ -554,8 +569,8 @@ class PetService {
 
         switch (operation.action) {
           case _actionAddVaccination:
-            final addData =
-                await _attachmentUploadService.resolvePendingAttachmentsInPayload(
+            final addData = await _attachmentUploadService
+                .resolvePendingAttachmentsInPayload(
                   _asPetMap(payload['data'] ?? const <String, dynamic>{}),
                 );
             final response = await _apiClient.post(
@@ -725,7 +740,9 @@ class PetService {
       return null;
     }
 
-    final mapped = await _localDb.getMetaValue('$_petIdMappingMetaPrefix$trimmed');
+    final mapped = await _localDb.getMetaValue(
+      '$_petIdMappingMetaPrefix$trimmed',
+    );
     final mappedTrimmed = mapped?.trim() ?? '';
     if (mappedTrimmed.isNotEmpty) {
       return mappedTrimmed;
@@ -814,27 +831,26 @@ class PetService {
     final currentVaccinations =
         (petJson['vaccinations'] as List<dynamic>?) ?? const <dynamic>[];
     final nextVaccinations = <Map<String, dynamic>>[];
+    Map<String, dynamic>? existingVaccination;
 
     for (final item in currentVaccinations) {
       final itemMap = _asPetMap(item);
       if (vaccinationId != null && vaccinationId.isNotEmpty) {
         final currentId = _readVaccinationRemoteId(itemMap);
         if (currentId == vaccinationId) {
+          existingVaccination = itemMap;
           continue;
         }
       }
       nextVaccinations.add(itemMap);
     }
 
-    nextVaccinations.add(vaccinationJson);
+    nextVaccinations.add({...?existingVaccination, ...vaccinationJson});
 
     await _localDb.upsertEntity(
       table: LocalDbTables.pets,
       remoteId: petId,
-      payload: <String, dynamic>{
-        ...petJson,
-        'vaccinations': nextVaccinations,
-      },
+      payload: <String, dynamic>{...petJson, 'vaccinations': nextVaccinations},
     );
   }
 
@@ -861,16 +877,17 @@ class PetService {
     await _localDb.upsertEntity(
       table: LocalDbTables.pets,
       remoteId: petId,
-      payload: <String, dynamic>{
-        ...petJson,
-        'vaccinations': nextVaccinations,
-      },
+      payload: <String, dynamic>{...petJson, 'vaccinations': nextVaccinations},
     );
   }
 
-  Future<List<PetVaccinationModel>> _getVaccinationsFromLocalDb(String petId) async {
+  Future<List<PetVaccinationModel>> _getVaccinationsFromLocalDb(
+    String petId,
+  ) async {
     try {
-      final localRows = await _localDb.getAllEntities(LocalDbTables.petVaccinations);
+      final localRows = await _localDb.getAllEntities(
+        LocalDbTables.petVaccinations,
+      );
       final filtered = localRows.where((item) {
         final rowPetId = item['petId'];
         return rowPetId is String && rowPetId.trim() == petId;
@@ -915,7 +932,9 @@ class PetService {
       'administeredBy': map['administeredBy'] ?? map['administered_by'] ?? '',
       'clinicName': map['clinicName'] ?? map['clinic_name'] ?? '',
       'attachedDocuments':
-          map['attachedDocuments'] ?? map['attached_documents'] ?? const <dynamic>[],
+          map['attachedDocuments'] ??
+          map['attached_documents'] ??
+          const <dynamic>[],
     };
   }
 }

--- a/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
+++ b/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
@@ -21,6 +21,7 @@ import '../../../../core/services/smart_feature_service.dart';
 import '../../../../core/services/telemetry_service.dart';
 import '../../../../shared/widgets/quick_actions_fab.dart';
 import '../../add_event/add_event_args.dart';
+import '../../add_vaccine/add_vaccine_args.dart';
 import '../../records/detail/detail_page.dart';
 import '../models/pet_ui_mapper.dart';
 import '../models/pet_ui_model.dart';
@@ -54,8 +55,13 @@ class _PetDetailScreenState extends State<PetDetailScreen>
   final TelemetryService _telemetryService = TelemetryService();
 
   Future<void> _goToAddVaccine() async {
-    final result = await Navigator.pushNamed(context, Routes.addVaccine);
+    final result = await Navigator.pushNamed(
+      context,
+      Routes.addVaccine,
+      arguments: AddVaccineArgs(petId: _pet.id, petName: _pet.name),
+    );
     if (result == true) {
+      _hasMutatedPet = true;
       await _loadPetDetail();
     }
   }
@@ -70,6 +76,11 @@ class _PetDetailScreenState extends State<PetDetailScreen>
       _hasMutatedPet = true;
       await _loadPetDetail();
     }
+  }
+
+  Future<void> _handleVaccinationUpdated() async {
+    _hasMutatedPet = true;
+    await _loadPetDetail();
   }
 
   late PetUiModel _pet;
@@ -520,6 +531,7 @@ class _PetDetailScreenState extends State<PetDetailScreen>
                 pet: _pet,
                 vaccinations: _petDetails?.vaccinations ?? const [],
                 onAddVaccine: _goToAddVaccine,
+                onVaccinationUpdated: _handleVaccinationUpdated,
               ),
               EventsTab(
                 pet: _pet,

--- a/lib/presentation/pages/pets/pet_detail/tabs/overview_tab.dart
+++ b/lib/presentation/pages/pets/pet_detail/tabs/overview_tab.dart
@@ -273,6 +273,28 @@ class _HealthSummaryCard extends StatelessWidget {
   final PetModel? petDetails;
   final int eventCount;
 
+  bool _isCompletedVaccination(PetVaccinationModel vaccination) {
+    final status = vaccination.status.trim().toLowerCase();
+    if (status == 'completed' || status == 'done' || status == 'applied') {
+      return true;
+    }
+
+    if (status == 'overdue' || status == 'late' || status == 'expired') {
+      return false;
+    }
+
+    final now = DateTime.now();
+    if (vaccination.nextDueDate.year > 1 &&
+        vaccination.nextDueDate.isBefore(now)) {
+      return false;
+    }
+    if (vaccination.dateGiven.year > 1 && vaccination.dateGiven.isAfter(now)) {
+      return false;
+    }
+
+    return true;
+  }
+
   @override
   Widget build(BuildContext context) {
     final bgColor = isDark
@@ -281,12 +303,9 @@ class _HealthSummaryCard extends StatelessWidget {
 
     final vaccinations = petDetails?.vaccinations ?? const [];
     final totalVaccines = vaccinations.length;
-    final upcoming =
-        vaccinations
-            .where((v) => v.nextDueDate.isAfter(DateTime.now()))
-            .toList(growable: false)
-          ..sort((a, b) => a.nextDueDate.compareTo(b.nextDueDate));
-    final completedVaccines = vaccinations.length - upcoming.length;
+    final completedVaccines = vaccinations
+        .where(_isCompletedVaccination)
+        .length;
     final vaccineMetric = totalVaccines == 0
         ? '0/0'
         : '$completedVaccines/$totalVaccines';

--- a/lib/presentation/pages/pets/pet_detail/tabs/vaccines_tab.dart
+++ b/lib/presentation/pages/pets/pet_detail/tabs/vaccines_tab.dart
@@ -10,7 +10,7 @@ import '../../../../../core/services/pet_service.dart';
 import '../../../../../core/services/vaccine_service.dart';
 import '../../models/pet_ui_model.dart';
 
-enum VaccineStatusType { completed, upcoming, overdue }
+enum VaccineStatusType { completed, overdue }
 
 class VaccineUiModel {
   VaccineUiModel({
@@ -40,7 +40,6 @@ class VaccineUiModel {
   String get statusLabel {
     return switch (status) {
       VaccineStatusType.completed => 'completed',
-      VaccineStatusType.upcoming => 'upcoming',
       VaccineStatusType.overdue => 'overdue',
     };
   }
@@ -71,11 +70,13 @@ class VaccinesTab extends StatefulWidget {
     required this.pet,
     required this.vaccinations,
     required this.onAddVaccine,
+    required this.onVaccinationUpdated,
   });
 
   final PetUiModel pet;
   final List<PetVaccinationModel> vaccinations;
   final VoidCallback onAddVaccine;
+  final Future<void> Function() onVaccinationUpdated;
 
   @override
   State<VaccinesTab> createState() => _VaccinesTabState();
@@ -175,18 +176,8 @@ class _VaccinesTabState extends State<VaccinesTab> {
       return VaccineStatusType.overdue;
     }
 
-    if (sourceStatus == 'upcoming' ||
-        sourceStatus == 'pending' ||
-        sourceStatus == 'scheduled') {
-      return VaccineStatusType.upcoming;
-    }
-
     if (model.nextDueDate.isBefore(now)) {
       return VaccineStatusType.overdue;
-    }
-
-    if (model.dateGiven.isAfter(now)) {
-      return VaccineStatusType.upcoming;
     }
 
     return VaccineStatusType.completed;
@@ -201,7 +192,6 @@ class _VaccinesTabState extends State<VaccinesTab> {
   String _statusToApiValue(VaccineStatusType status) {
     return switch (status) {
       VaccineStatusType.completed => 'completed',
-      VaccineStatusType.upcoming => 'upcoming',
       VaccineStatusType.overdue => 'overdue',
     };
   }
@@ -209,7 +199,6 @@ class _VaccinesTabState extends State<VaccinesTab> {
   String _statusLabel(VaccineStatusType status) {
     return switch (status) {
       VaccineStatusType.completed => 'Completed',
-      VaccineStatusType.upcoming => 'Upcoming',
       VaccineStatusType.overdue => 'Overdue',
     };
   }
@@ -300,6 +289,12 @@ class _VaccinesTabState extends State<VaccinesTab> {
       setState(() {
         _statusOverrides[key] = newStatus;
       });
+
+      await widget.onVaccinationUpdated();
+
+      if (!mounted) {
+        return;
+      }
 
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
@@ -404,9 +399,6 @@ class _VaccinesTabState extends State<VaccinesTab> {
     final completed = uiVaccines
         .where((i) => i.status == VaccineStatusType.completed)
         .length;
-    final upcoming = uiVaccines
-        .where((i) => i.status == VaccineStatusType.upcoming)
-        .length;
     final overdue = uiVaccines
         .where((i) => i.status == VaccineStatusType.overdue)
         .length;
@@ -446,7 +438,6 @@ class _VaccinesTabState extends State<VaccinesTab> {
           ),
           child: VaccinesStatusSummary(
             completedCount: completed,
-            upcomingCount: upcoming,
             overdueCount: overdue,
           ),
         ),
@@ -558,12 +549,10 @@ class VaccinesStatusSummary extends StatelessWidget {
   const VaccinesStatusSummary({
     super.key,
     required this.completedCount,
-    required this.upcomingCount,
     required this.overdueCount,
   });
 
   final int completedCount;
-  final int upcomingCount;
   final int overdueCount;
 
   @override
@@ -576,15 +565,6 @@ class VaccinesStatusSummary extends StatelessWidget {
             count: completedCount,
             textColor: AppColors.vaccineStatusCompletedText,
             backgroundColor: AppColors.vaccineStatusCompletedBg,
-          ),
-        ),
-        const SizedBox(width: AppDimensions.spaceS),
-        Expanded(
-          child: _StatusChip(
-            label: 'Upcoming',
-            count: upcomingCount,
-            textColor: AppColors.vaccineStatusUpcomingText,
-            backgroundColor: AppColors.vaccineStatusUpcomingBg,
           ),
         ),
         const SizedBox(width: AppDimensions.spaceS),
@@ -730,7 +710,6 @@ class TimelineIndicator extends StatelessWidget {
   String get _iconPath {
     return switch (status) {
       VaccineStatusType.completed => 'assets/icons/status/successPrimary.svg',
-      VaccineStatusType.upcoming => 'assets/icons/status/pendingPrimary.svg',
       VaccineStatusType.overdue => 'assets/icons/status/warningPrimary.svg',
     };
   }
@@ -758,7 +737,6 @@ class VaccineCard extends StatelessWidget {
   Color get _badgeColor {
     return switch (vaccine.status) {
       VaccineStatusType.completed => AppColors.vaccineStatusCompletedBg,
-      VaccineStatusType.upcoming => AppColors.vaccineStatusUpcomingBg,
       VaccineStatusType.overdue => AppColors.vaccineStatusOverdueBg,
     };
   }
@@ -766,7 +744,6 @@ class VaccineCard extends StatelessWidget {
   Color get _badgeTextColor {
     return switch (vaccine.status) {
       VaccineStatusType.completed => AppColors.vaccineStatusCompletedText,
-      VaccineStatusType.upcoming => AppColors.vaccineStatusUpcomingText,
       VaccineStatusType.overdue => AppColors.vaccineStatusOverdueText,
     };
   }


### PR DESCRIPTION
## Summary
- Refresh pet detail after vaccine status updates so the health summary stays in sync
- Remove upcoming as a selectable vaccine status for applied vaccinations
- Prefill the current pet when adding vaccines from pet detail

## Validation
- flutter analyze

Closes #97