### PR TITLE
Add telemetry for cached pet profile loading

### DIFF
--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -7,6 +7,7 @@ import '../network/api_exception.dart';
 import 'attachment_upload_service.dart';
 import 'local_database_service.dart';
 import 'response_cache_service.dart';
+import 'telemetry_service.dart';
 
 class PetService {
   PetService._();
@@ -37,16 +38,26 @@ class PetService {
   final LocalDatabaseService _localDb = LocalDatabaseService();
   final AttachmentUploadService _attachmentUploadService =
       AttachmentUploadService();
+  final TelemetryService _telemetryService = TelemetryService();
 
   Future<List<PetModel>> getPets({bool forceRefresh = false}) async {
     final cachedEntry = await _cache.get(_petsCacheKey);
     if (!forceRefresh &&
         cachedEntry != null &&
         cachedEntry.isFresh(_petsCacheTtl)) {
+      final cacheLoadStartTime = DateTime.now();
       final cachedPets = _tryParsePets(cachedEntry.body);
       if (cachedPets != null) {
         unawaited(_persistPetsFromBody(cachedEntry.body));
-        return await _mergeLocalPets(cachedPets);
+        final mergedPets = await _mergeLocalPets(cachedPets);
+        final cacheLoadEndTime = DateTime.now();
+        unawaited(
+          _telemetryService.logCachedPetProfileLoadExecution(
+            startTime: cacheLoadStartTime,
+            endTime: cacheLoadEndTime,
+          ),
+        );
+        return mergedPets;
       }
     }
 

--- a/lib/core/services/telemetry_service.dart
+++ b/lib/core/services/telemetry_service.dart
@@ -182,6 +182,39 @@ class TelemetryService {
     }
   }
 
+  Future<void> logCachedPetProfileLoadExecution({
+    required DateTime startTime,
+    required DateTime endTime,
+  }) async {
+    if (featureLoadCachedPetProfileId.isEmpty) {
+      return;
+    }
+
+    final userId = await _getUserId();
+    if (userId == null) {
+      return;
+    }
+
+    final totalTimeMs = endTime.difference(startTime).inMilliseconds;
+    final payload = <String, dynamic>{
+      'schema': 1,
+      'userId': userId,
+      'featureId': featureLoadCachedPetProfileId,
+      'startTime': startTime.toIso8601String(),
+      'endTime': endTime.toIso8601String(),
+      'totalTime': totalTimeMs,
+      'downloadSpeed': 0,
+      'uploadSpeed': 0,
+      'appType': 'Flutter',
+    };
+
+    try {
+      await _apiClient.post(_featureExecutionLogsPath, body: payload);
+    } catch (_) {
+      // Telemetry should never block the UI or crash the app.
+    }
+  }
+
   Future<String?> _getUserId() async {
     final cached = _cachedUserId;
     if (cached != null && cached.isNotEmpty) {

--- a/lib/core/telemetry/telemetry_ids.dart
+++ b/lib/core/telemetry/telemetry_ids.dart
@@ -4,3 +4,4 @@ const String featureNfcReadId = '69bc1bf92fb48df4a28aaf07';
 const String featureAddPetId = '69bc446a2fb48df4a28aaf1e';
 const String featureEditPetId = '69bd781c3bc6bfe99e3d4b2a';
 const String featureRouteAddEventId = '69bc1d2f2fb48df4a28aaf0a';
+const String featureLoadCachedPetProfileId = '69eb8daba8c0fdbb7a4bde54';


### PR DESCRIPTION
Implement telemetry logging for the loading of cached pet profiles to monitor performance. 