### PR TITLE
Log attachment upload telemetry for Type 1 question

### DIFF
--- a/lib/core/models/attachment_models.dart
+++ b/lib/core/models/attachment_models.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 class UploadedAttachmentModel {
   const UploadedAttachmentModel({
     required this.fileName,
@@ -58,5 +60,80 @@ class EditableAttachmentModel {
       if (contentType.trim().isNotEmpty) 'contentType': contentType,
       if (sizeBytes > 0) 'sizeBytes': sizeBytes,
     };
+  }
+}
+
+enum AttachmentUploadStatus { queued, processing, uploading, succeeded, failed }
+
+class PendingAttachmentUpload {
+  const PendingAttachmentUpload({
+    required this.localId,
+    required this.fileName,
+    required this.bytes,
+    required this.category,
+    required this.isImage,
+  });
+
+  final String localId;
+  final String fileName;
+  final Uint8List bytes;
+  final String category;
+  final bool isImage;
+}
+
+class AttachmentUploadItem {
+  const AttachmentUploadItem({
+    required this.localId,
+    required this.fileName,
+    required this.status,
+    this.errorMessage,
+    this.attachment,
+  });
+
+  final String localId;
+  final String fileName;
+  final AttachmentUploadStatus status;
+  final String? errorMessage;
+  final EditableAttachmentModel? attachment;
+
+  bool get isPending =>
+      status == AttachmentUploadStatus.queued ||
+      status == AttachmentUploadStatus.processing ||
+      status == AttachmentUploadStatus.uploading;
+
+  bool get isFailed => status == AttachmentUploadStatus.failed;
+  bool get isSucceeded => status == AttachmentUploadStatus.succeeded;
+
+  AttachmentUploadItem copyWith({
+    String? localId,
+    String? fileName,
+    AttachmentUploadStatus? status,
+    String? errorMessage,
+    bool clearErrorMessage = false,
+    EditableAttachmentModel? attachment,
+    bool clearAttachment = false,
+  }) {
+    return AttachmentUploadItem(
+      localId: localId ?? this.localId,
+      fileName: fileName ?? this.fileName,
+      status: status ?? this.status,
+      errorMessage: clearErrorMessage
+          ? null
+          : (errorMessage ?? this.errorMessage),
+      attachment: clearAttachment ? null : (attachment ?? this.attachment),
+    );
+  }
+
+  factory AttachmentUploadItem.fromExisting(
+    EditableAttachmentModel attachment,
+  ) {
+    return AttachmentUploadItem(
+      localId: attachment.documentId?.trim().isNotEmpty == true
+          ? 'existing-${attachment.documentId!.trim()}'
+          : 'existing-${attachment.fileName}-${attachment.fileUri}',
+      fileName: attachment.fileName,
+      status: AttachmentUploadStatus.succeeded,
+      attachment: attachment,
+    );
   }
 }

--- a/lib/core/services/attachment_preprocessing_service.dart
+++ b/lib/core/services/attachment_preprocessing_service.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/foundation.dart';
+import 'package:image/image.dart' as img;
+
+class AttachmentPreprocessingService {
+  const AttachmentPreprocessingService();
+
+  Future<Uint8List> preprocessImageForUpload({
+    required Uint8List bytes,
+    required String fileName,
+  }) {
+    return compute(
+      _preprocessImagePayload,
+      _ImagePreprocessPayload(bytes: bytes, fileName: fileName),
+    );
+  }
+}
+
+class _ImagePreprocessPayload {
+  const _ImagePreprocessPayload({required this.bytes, required this.fileName});
+
+  final Uint8List bytes;
+  final String fileName;
+}
+
+Uint8List _preprocessImagePayload(_ImagePreprocessPayload payload) {
+  final decoded = img.decodeImage(payload.bytes);
+  if (decoded == null) {
+    return payload.bytes;
+  }
+
+  final resized = decoded.width > 1600 || decoded.height > 1600
+      ? img.copyResize(
+          decoded,
+          width: decoded.width >= decoded.height ? 1600 : null,
+          height: decoded.height > decoded.width ? 1600 : null,
+          interpolation: img.Interpolation.average,
+        )
+      : decoded;
+
+  final extension = payload.fileName.trim().toLowerCase().split('.').last;
+  switch (extension) {
+    case 'png':
+      return Uint8List.fromList(img.encodePng(resized));
+    case 'jpg':
+    case 'jpeg':
+      return Uint8List.fromList(img.encodeJpg(resized, quality: 82));
+    default:
+      return payload.bytes;
+  }
+}

--- a/lib/core/services/attachment_upload_coordinator.dart
+++ b/lib/core/services/attachment_upload_coordinator.dart
@@ -1,19 +1,25 @@
+import 'dart:async';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_frontend/core/models/attachment_models.dart';
 
 import 'attachment_preprocessing_service.dart';
 import 'attachment_upload_service.dart';
+import 'telemetry_service.dart';
 
 class AttachmentUploadCoordinator extends ChangeNotifier {
   AttachmentUploadCoordinator({
     AttachmentUploadService? uploadService,
     AttachmentPreprocessingService? preprocessingService,
+    TelemetryService? telemetryService,
   }) : _uploadService = uploadService ?? AttachmentUploadService(),
        _preprocessingService =
-           preprocessingService ?? const AttachmentPreprocessingService();
+           preprocessingService ?? const AttachmentPreprocessingService(),
+       _telemetryService = telemetryService ?? TelemetryService();
 
   final AttachmentUploadService _uploadService;
   final AttachmentPreprocessingService _preprocessingService;
+  final TelemetryService _telemetryService;
   final List<AttachmentUploadItem> _items = <AttachmentUploadItem>[];
   final Map<String, _QueuedAttachmentUpload> _queuedUploads =
       <String, _QueuedAttachmentUpload>{};
@@ -122,6 +128,7 @@ class AttachmentUploadCoordinator extends ChangeNotifier {
         }
 
         try {
+          final startTime = DateTime.now();
           Uint8List bytes = request.upload.bytes;
           if (request.upload.isImage) {
             _updateStatus(
@@ -153,6 +160,7 @@ class AttachmentUploadCoordinator extends ChangeNotifier {
             fileName: request.upload.fileName,
             category: request.upload.category,
           );
+          final endTime = DateTime.now();
 
           _updateStatus(
             nextItem.localId,
@@ -160,6 +168,15 @@ class AttachmentUploadCoordinator extends ChangeNotifier {
               status: AttachmentUploadStatus.succeeded,
               attachment: EditableAttachmentModel.fromUploaded(uploaded),
               clearErrorMessage: true,
+            ),
+          );
+
+          unawaited(
+            _logAttachmentUploadExecution(
+              category: request.upload.category,
+              startTime: startTime,
+              endTime: endTime,
+              uploadBytes: bytes.lengthInBytes,
             ),
           );
         } catch (error) {
@@ -193,6 +210,32 @@ class AttachmentUploadCoordinator extends ChangeNotifier {
     }
     _items[index] = updatedItem;
     notifyListeners();
+  }
+
+  Future<void> _logAttachmentUploadExecution({
+    required String category,
+    required DateTime startTime,
+    required DateTime endTime,
+    required int uploadBytes,
+  }) async {
+    switch (category.trim().toLowerCase()) {
+      case 'vaccinations':
+        await _telemetryService.logVaccineAttachmentUploadExecution(
+          startTime: startTime,
+          endTime: endTime,
+          uploadBytes: uploadBytes,
+        );
+        break;
+      case 'events':
+        await _telemetryService.logEventAttachmentUploadExecution(
+          startTime: startTime,
+          endTime: endTime,
+          uploadBytes: uploadBytes,
+        );
+        break;
+      default:
+        break;
+    }
   }
 }
 

--- a/lib/core/services/attachment_upload_coordinator.dart
+++ b/lib/core/services/attachment_upload_coordinator.dart
@@ -1,0 +1,204 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_frontend/core/models/attachment_models.dart';
+
+import 'attachment_preprocessing_service.dart';
+import 'attachment_upload_service.dart';
+
+class AttachmentUploadCoordinator extends ChangeNotifier {
+  AttachmentUploadCoordinator({
+    AttachmentUploadService? uploadService,
+    AttachmentPreprocessingService? preprocessingService,
+  }) : _uploadService = uploadService ?? AttachmentUploadService(),
+       _preprocessingService =
+           preprocessingService ?? const AttachmentPreprocessingService();
+
+  final AttachmentUploadService _uploadService;
+  final AttachmentPreprocessingService _preprocessingService;
+  final List<AttachmentUploadItem> _items = <AttachmentUploadItem>[];
+  final Map<String, _QueuedAttachmentUpload> _queuedUploads =
+      <String, _QueuedAttachmentUpload>{};
+
+  bool _isProcessing = false;
+
+  List<AttachmentUploadItem> get items => List.unmodifiable(_items);
+
+  bool get hasPendingUploads => _items.any((item) => item.isPending);
+
+  bool get hasFailedUploads => _items.any((item) => item.isFailed);
+
+  bool get canSubmit => !hasPendingUploads && !hasFailedUploads;
+
+  void initializeFromExisting(List<EditableAttachmentModel> attachments) {
+    _items
+      ..clear()
+      ..addAll(attachments.map(AttachmentUploadItem.fromExisting));
+    _queuedUploads.clear();
+    notifyListeners();
+  }
+
+  Future<void> enqueueUploads({
+    required String petId,
+    required List<PendingAttachmentUpload> uploads,
+  }) async {
+    for (final upload in uploads) {
+      _queuedUploads[upload.localId] = _QueuedAttachmentUpload(
+        petId: petId,
+        upload: upload,
+      );
+      _items.add(
+        AttachmentUploadItem(
+          localId: upload.localId,
+          fileName: upload.fileName,
+          status: AttachmentUploadStatus.queued,
+        ),
+      );
+    }
+
+    notifyListeners();
+    await _processQueue();
+  }
+
+  Future<void> retry(String localId) async {
+    final queuedUpload = _queuedUploads[localId];
+    if (queuedUpload == null) {
+      return;
+    }
+
+    final index = _indexOfLocalId(localId);
+    if (index == -1) {
+      return;
+    }
+
+    _items[index] = _items[index].copyWith(
+      status: AttachmentUploadStatus.queued,
+      clearErrorMessage: true,
+      clearAttachment: true,
+    );
+    notifyListeners();
+    await _processQueue();
+  }
+
+  void remove(String localId) {
+    _queuedUploads.remove(localId);
+    _items.removeWhere((item) => item.localId == localId);
+    notifyListeners();
+  }
+
+  List<EditableAttachmentModel> buildSucceededPayload() {
+    return _items
+        .where((item) => item.isSucceeded && item.attachment != null)
+        .map((item) => item.attachment!)
+        .toList(growable: false);
+  }
+
+  Future<void> _processQueue() async {
+    if (_isProcessing) {
+      return;
+    }
+
+    _isProcessing = true;
+    try {
+      while (true) {
+        final nextItem = _items.cast<AttachmentUploadItem?>().firstWhere(
+          (item) =>
+              item != null && item.status == AttachmentUploadStatus.queued,
+          orElse: () => null,
+        );
+        if (nextItem == null) {
+          break;
+        }
+
+        final request = _queuedUploads[nextItem.localId];
+        if (request == null) {
+          _updateStatus(
+            nextItem.localId,
+            nextItem.copyWith(
+              status: AttachmentUploadStatus.failed,
+              errorMessage: 'Missing upload data.',
+              clearAttachment: true,
+            ),
+          );
+          continue;
+        }
+
+        try {
+          Uint8List bytes = request.upload.bytes;
+          if (request.upload.isImage) {
+            _updateStatus(
+              nextItem.localId,
+              nextItem.copyWith(
+                status: AttachmentUploadStatus.processing,
+                clearErrorMessage: true,
+                clearAttachment: true,
+              ),
+            );
+            bytes = await _preprocessingService.preprocessImageForUpload(
+              bytes: bytes,
+              fileName: request.upload.fileName,
+            );
+          }
+
+          _updateStatus(
+            nextItem.localId,
+            _itemById(nextItem.localId).copyWith(
+              status: AttachmentUploadStatus.uploading,
+              clearErrorMessage: true,
+              clearAttachment: true,
+            ),
+          );
+
+          final uploaded = await _uploadService.uploadPetDocument(
+            bytes: bytes,
+            petId: request.petId,
+            fileName: request.upload.fileName,
+            category: request.upload.category,
+          );
+
+          _updateStatus(
+            nextItem.localId,
+            _itemById(nextItem.localId).copyWith(
+              status: AttachmentUploadStatus.succeeded,
+              attachment: EditableAttachmentModel.fromUploaded(uploaded),
+              clearErrorMessage: true,
+            ),
+          );
+        } catch (error) {
+          _updateStatus(
+            nextItem.localId,
+            _itemById(nextItem.localId).copyWith(
+              status: AttachmentUploadStatus.failed,
+              errorMessage: error.toString(),
+              clearAttachment: true,
+            ),
+          );
+        }
+      }
+    } finally {
+      _isProcessing = false;
+    }
+  }
+
+  int _indexOfLocalId(String localId) {
+    return _items.indexWhere((item) => item.localId == localId);
+  }
+
+  AttachmentUploadItem _itemById(String localId) {
+    return _items.firstWhere((item) => item.localId == localId);
+  }
+
+  void _updateStatus(String localId, AttachmentUploadItem updatedItem) {
+    final index = _indexOfLocalId(localId);
+    if (index == -1) {
+      return;
+    }
+    _items[index] = updatedItem;
+    notifyListeners();
+  }
+}
+
+class _QueuedAttachmentUpload {
+  const _QueuedAttachmentUpload({required this.petId, required this.upload});
+
+  final String petId;
+  final PendingAttachmentUpload upload;
+}

--- a/lib/core/services/telemetry_service.dart
+++ b/lib/core/services/telemetry_service.dart
@@ -52,31 +52,11 @@ class TelemetryService {
     required DateTime startTime,
     required DateTime endTime,
   }) async {
-    if (featureNfcReadId.isEmpty) {
-      return;
-    }
-
-    final userId = await _getUserId();
-    if (userId == null) {
-      return;
-    }
-
-    final totalTimeMs = endTime.difference(startTime).inMilliseconds;
-    final payload = <String, dynamic>{
-      'schema': 1,
-      'userId': userId,
-      'featureId': featureNfcReadId,
-      'startTime': startTime.toIso8601String(),
-      'endTime': endTime.toIso8601String(),
-      'totalTime': totalTimeMs,
-      'appType' : "Flutter"
-    };
-
-    try {
-      await _apiClient.post(_featureExecutionLogsPath, body: payload);
-    } catch (_) {
-      // Telemetry should never block the UI or crash the app.
-    }
+    await _logFeatureExecution(
+      featureId: featureNfcReadId,
+      startTime: startTime,
+      endTime: endTime,
+    );
   }
 
   Future<void> logAddPetExecutionIfPending({required DateTime endTime}) async {
@@ -114,7 +94,7 @@ class TelemetryService {
       'totalTime': totalTimeMs,
       'uploadSpeed': uploadSpeed,
       'downloadSpeed': downloadSpeed,
-      'appType' : "Flutter"
+      'appType': "Flutter",
     };
 
     try {
@@ -144,7 +124,7 @@ class TelemetryService {
       'routeId': featureRouteAddEventId,
       'timestamp': DateTime.now().toIso8601String(),
       'nClicks': nClicks,
-      'appType' : "Flutter"
+      'appType': "Flutter",
     };
 
     try {
@@ -172,7 +152,7 @@ class TelemetryService {
       'startTime': startTime.toIso8601String(),
       'endTime': endTime.toIso8601String(),
       'totalTime': totalTimeMs,
-      'appType' : "Flutter"
+      'appType': "Flutter",
     };
 
     try {
@@ -180,6 +160,32 @@ class TelemetryService {
     } catch (_) {
       // Telemetry should never block the UI or crash the app.
     }
+  }
+
+  Future<void> logVaccineAttachmentUploadExecution({
+    required DateTime startTime,
+    required DateTime endTime,
+    required int uploadBytes,
+  }) async {
+    await _logFeatureExecution(
+      featureId: featureVaccineAttachmentUploadId,
+      startTime: startTime,
+      endTime: endTime,
+      uploadBytes: uploadBytes,
+    );
+  }
+
+  Future<void> logEventAttachmentUploadExecution({
+    required DateTime startTime,
+    required DateTime endTime,
+    required int uploadBytes,
+  }) async {
+    await _logFeatureExecution(
+      featureId: featureEventAttachmentUploadId,
+      startTime: startTime,
+      endTime: endTime,
+      uploadBytes: uploadBytes,
+    );
   }
 
   Future<String?> _getUserId() async {
@@ -194,6 +200,50 @@ class TelemetryService {
       return user.id;
     } catch (_) {
       return null;
+    }
+  }
+
+  Future<void> _logFeatureExecution({
+    required String featureId,
+    required DateTime startTime,
+    required DateTime endTime,
+    int uploadBytes = 0,
+    int downloadBytes = 0,
+  }) async {
+    if (featureId.trim().isEmpty) {
+      return;
+    }
+
+    final userId = await _getUserId();
+    if (userId == null) {
+      return;
+    }
+
+    final totalTimeMs = endTime.difference(startTime).inMilliseconds;
+    final totalSeconds = totalTimeMs <= 0 ? 0 : totalTimeMs / 1000.0;
+    final uploadSpeed = totalSeconds == 0
+        ? 0
+        : (uploadBytes / totalSeconds).round();
+    final downloadSpeed = totalSeconds == 0
+        ? 0
+        : (downloadBytes / totalSeconds).round();
+
+    final payload = <String, dynamic>{
+      'schema': 1,
+      'userId': userId,
+      'featureId': featureId,
+      'startTime': startTime.toIso8601String(),
+      'endTime': endTime.toIso8601String(),
+      'totalTime': totalTimeMs,
+      'uploadSpeed': uploadSpeed,
+      'downloadSpeed': downloadSpeed,
+      'appType': 'Flutter',
+    };
+
+    try {
+      await _apiClient.post(_featureExecutionLogsPath, body: payload);
+    } catch (_) {
+      // Telemetry should never block the UI or crash the app.
     }
   }
 

--- a/lib/core/telemetry/telemetry_ids.dart
+++ b/lib/core/telemetry/telemetry_ids.dart
@@ -4,5 +4,5 @@ const String featureNfcReadId = '69bc1bf92fb48df4a28aaf07';
 const String featureAddPetId = '69bc446a2fb48df4a28aaf1e';
 const String featureEditPetId = '69bd781c3bc6bfe99e3d4b2a';
 const String featureRouteAddEventId = '69bc1d2f2fb48df4a28aaf0a';
-const String featureVaccineAttachmentUploadId = '6809f0a1c0de3510a0000001';
-const String featureEventAttachmentUploadId = '6809f0a1c0de3510a0000002';
+const String featureVaccineAttachmentUploadId = '69eb92ef4e5c181e934ea67f';
+const String featureEventAttachmentUploadId = '69eb93064e5c181e934ea680';

--- a/lib/core/telemetry/telemetry_ids.dart
+++ b/lib/core/telemetry/telemetry_ids.dart
@@ -4,3 +4,5 @@ const String featureNfcReadId = '69bc1bf92fb48df4a28aaf07';
 const String featureAddPetId = '69bc446a2fb48df4a28aaf1e';
 const String featureEditPetId = '69bd781c3bc6bfe99e3d4b2a';
 const String featureRouteAddEventId = '69bc1d2f2fb48df4a28aaf0a';
+const String featureVaccineAttachmentUploadId = '6809f0a1c0de3510a0000001';
+const String featureEventAttachmentUploadId = '6809f0a1c0de3510a0000002';

--- a/lib/presentation/pages/add_event/add_event_page.dart
+++ b/lib/presentation/pages/add_event/add_event_page.dart
@@ -832,10 +832,7 @@ class _AddEventPageState extends State<AddEventPage> {
       }
 
       _didTouchAttachments = true;
-      await _attachmentUploadCoordinator.enqueueUploads(
-        petId: petId,
-        uploads: uploads,
-      );
+      _startAttachmentUploads(petId: petId, uploads: uploads);
     } catch (_) {
       if (!mounted) {
         return;
@@ -845,6 +842,30 @@ class _AddEventPageState extends State<AddEventPage> {
         context,
       ).showSnackBar(const SnackBar(content: Text(AppStrings.errorGeneric)));
     }
+  }
+
+  void _startAttachmentUploads({
+    required String petId,
+    required List<PendingAttachmentUpload> uploads,
+  }) {
+    unawaited(
+      _attachmentUploadCoordinator
+          .enqueueUploads(petId: petId, uploads: uploads)
+          .then((_) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {});
+          })
+          .catchError((_) {
+            if (!mounted) {
+              return;
+            }
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text(AppStrings.errorGeneric)),
+            );
+          }),
+    );
   }
 
   Future<_AttachmentSource?> _showAttachmentSourcePicker() {

--- a/lib/presentation/pages/add_event/add_event_page.dart
+++ b/lib/presentation/pages/add_event/add_event_page.dart
@@ -8,7 +8,7 @@ import 'package:flutter_frontend/core/forms/app_form_utils.dart';
 import 'package:flutter_frontend/core/models/attachment_models.dart';
 import 'package:flutter_frontend/core/models/event_model.dart';
 import 'package:flutter_frontend/core/models/pet_model.dart';
-import 'package:flutter_frontend/core/services/attachment_upload_service.dart';
+import 'package:flutter_frontend/core/services/attachment_upload_coordinator.dart';
 import 'package:flutter_frontend/core/services/event_service.dart';
 import 'package:flutter_frontend/core/services/pet_service.dart';
 import 'package:flutter_frontend/core/services/telemetry_service.dart';
@@ -49,16 +49,13 @@ class _AddEventPageState extends State<AddEventPage> {
   final PetService _petService = PetService();
   final EventService _eventService = EventService();
   final TelemetryService _telemetryService = TelemetryService();
-  final AttachmentUploadService _attachmentUploadService =
-      AttachmentUploadService();
+  final AttachmentUploadCoordinator _attachmentUploadCoordinator =
+      AttachmentUploadCoordinator();
   final ImagePicker _imagePicker = ImagePicker();
   final List<PetModel> _pets = [];
-  final List<EditableAttachmentModel> _attachedDocuments = [];
 
   bool _isLoadingPets = false;
   bool _isSubmitting = false;
-  bool _isUploadingAttachments = false;
-  bool _isLoadingExistingAttachments = false;
   bool _didTouchAttachments = false;
   bool _didHydrateExistingAttachments = false;
   String? _selectedPetName;
@@ -74,6 +71,7 @@ class _AddEventPageState extends State<AddEventPage> {
   void initState() {
     super.initState();
     _eventController.addListener(_syncEventTypeFromTitle);
+    _attachmentUploadCoordinator.addListener(_handleAttachmentUploadsChanged);
     _applyPrefill(widget.prefill);
     _loadPets();
     _loadEditingEventIfNeeded();
@@ -83,6 +81,10 @@ class _AddEventPageState extends State<AddEventPage> {
   void dispose() {
     _dateController.dispose();
     _eventController.dispose();
+    _attachmentUploadCoordinator.removeListener(
+      _handleAttachmentUploadsChanged,
+    );
+    _attachmentUploadCoordinator.dispose();
     _timeController.dispose();
     _eventTypeController.dispose();
     _priceController.dispose();
@@ -149,17 +151,18 @@ class _AddEventPageState extends State<AddEventPage> {
       _followUpDateController.text = formatDateForInput(prefill.followUpDate!);
     }
 
-    _attachedDocuments
-      ..clear()
-      ..addAll(
-        (prefill.attachedDocuments ?? const <EventDocumentModel>[]).map(
-          (document) => EditableAttachmentModel(
-            fileName: document.fileName,
-            fileUri: document.fileUri,
-            documentId: document.documentId,
-          ),
-        ),
-      );
+    final existingAttachments =
+        (prefill.attachedDocuments ?? const <EventDocumentModel>[])
+            .map(
+              (document) => EditableAttachmentModel(
+                fileName: document.fileName,
+                fileUri: document.fileUri,
+                documentId: document.documentId,
+              ),
+            )
+            .toList(growable: false);
+    _attachmentUploadCoordinator.initializeFromExisting(existingAttachments);
+    _didHydrateExistingAttachments = existingAttachments.isNotEmpty;
 
     if (_pets.isNotEmpty) {
       _applyPetSelectionFromPrefill(prefill);
@@ -189,12 +192,6 @@ class _AddEventPageState extends State<AddEventPage> {
     }
 
     try {
-      if (mounted) {
-        setState(() {
-          _isLoadingExistingAttachments = true;
-        });
-      }
-
       final event = await _eventService.getEventById(eventId);
       if (!mounted) {
         return;
@@ -232,27 +229,21 @@ class _AddEventPageState extends State<AddEventPage> {
           );
         }
 
-        _attachedDocuments
-          ..clear()
-          ..addAll(
-            event.attachedDocuments.map(
-              (document) => EditableAttachmentModel(
-                fileName: document.fileName,
-                fileUri: document.fileUri,
-                documentId: document.documentId,
-              ),
-            ),
-          );
+        _attachmentUploadCoordinator.initializeFromExisting(
+          event.attachedDocuments
+              .map(
+                (document) => EditableAttachmentModel(
+                  fileName: document.fileName,
+                  fileUri: document.fileUri,
+                  documentId: document.documentId,
+                ),
+              )
+              .toList(growable: false),
+        );
         _didHydrateExistingAttachments = true;
       });
     } catch (_) {
       // Keep the form usable even if hydration fails.
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoadingExistingAttachments = false;
-        });
-      }
     }
   }
 
@@ -659,6 +650,17 @@ class _AddEventPageState extends State<AddEventPage> {
       return;
     }
 
+    if (!_attachmentUploadCoordinator.canSubmit) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Finish uploading or remove failed attachments before saving.',
+          ),
+        ),
+      );
+      return;
+    }
+
     final selectedDate = parseDateInput(_dateController.text.trim());
     if (selectedDate == null) {
       ScaffoldMessenger.of(
@@ -748,7 +750,8 @@ class _AddEventPageState extends State<AddEventPage> {
         'clinic': _clinicController.text.trim(),
         'description': _descriptionController.text.trim(),
         'followUpDate': followUpDateIso,
-        'attachedDocuments': _attachedDocuments
+        'attachedDocuments': _attachmentUploadCoordinator
+            .buildSucceededPayload()
             .map((attachment) => attachment.toPayload())
             .toList(growable: false),
       };
@@ -820,18 +823,19 @@ class _AddEventPageState extends State<AddEventPage> {
       }
 
       final uploads = switch (source) {
-        _AttachmentSource.files => await _pickFilesForAttachment(petId),
-        _AttachmentSource.camera => await _capturePhotoForAttachment(petId),
+        _AttachmentSource.files => await _pickFilesForAttachment(),
+        _AttachmentSource.camera => await _capturePhotoForAttachment(),
       };
 
       if (uploads.isEmpty || !mounted) {
         return;
       }
 
-      setState(() {
-        _attachedDocuments.addAll(uploads);
-        _didTouchAttachments = true;
-      });
+      _didTouchAttachments = true;
+      await _attachmentUploadCoordinator.enqueueUploads(
+        petId: petId,
+        uploads: uploads,
+      );
     } catch (_) {
       if (!mounted) {
         return;
@@ -840,10 +844,6 @@ class _AddEventPageState extends State<AddEventPage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text(AppStrings.errorGeneric)));
-    } finally {
-      if (mounted) {
-        setState(() => _isUploadingAttachments = false);
-      }
     }
   }
 
@@ -877,9 +877,7 @@ class _AddEventPageState extends State<AddEventPage> {
     );
   }
 
-  Future<List<EditableAttachmentModel>> _pickFilesForAttachment(
-    String petId,
-  ) async {
+  Future<List<PendingAttachmentUpload>> _pickFilesForAttachment() async {
     final result = await FilePicker.platform.pickFiles(
       allowMultiple: true,
       withData: true,
@@ -888,37 +886,36 @@ class _AddEventPageState extends State<AddEventPage> {
     );
 
     if (result == null || result.files.isEmpty) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     if (!mounted) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
-    setState(() => _isUploadingAttachments = true);
-
-    final uploads = <EditableAttachmentModel>[];
-    for (final file in result.files) {
+    final uploads = <PendingAttachmentUpload>[];
+    for (var index = 0; index < result.files.length; index++) {
+      final file = result.files[index];
       final bytes = file.bytes;
       if (bytes == null || bytes.isEmpty) {
         continue;
       }
 
-      final uploaded = await _attachmentUploadService.uploadPetDocument(
-        bytes: bytes,
-        petId: petId,
-        fileName: file.name,
-        category: 'events',
+      uploads.add(
+        PendingAttachmentUpload(
+          localId: _buildAttachmentLocalId(fileName: file.name, index: index),
+          fileName: file.name,
+          bytes: bytes,
+          category: 'events',
+          isImage: _isImageFile(file.name),
+        ),
       );
-      uploads.add(EditableAttachmentModel.fromUploaded(uploaded));
     }
 
     return uploads;
   }
 
-  Future<List<EditableAttachmentModel>> _capturePhotoForAttachment(
-    String petId,
-  ) async {
+  Future<List<PendingAttachmentUpload>> _capturePhotoForAttachment() async {
     final photo = await _imagePicker.pickImage(
       source: ImageSource.camera,
       imageQuality: 85,
@@ -927,41 +924,57 @@ class _AddEventPageState extends State<AddEventPage> {
     );
 
     if (photo == null) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     final bytes = await photo.readAsBytes();
     if (bytes.isEmpty) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     if (!mounted) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
-    setState(() => _isUploadingAttachments = true);
-
-    final uploaded = await _attachmentUploadService.uploadPetDocument(
-      bytes: bytes,
-      petId: petId,
-      fileName: photo.name,
-      category: 'events',
-    );
-
-    return <EditableAttachmentModel>[
-      EditableAttachmentModel.fromUploaded(uploaded),
+    return <PendingAttachmentUpload>[
+      PendingAttachmentUpload(
+        localId: _buildAttachmentLocalId(fileName: photo.name),
+        fileName: photo.name,
+        bytes: bytes,
+        category: 'events',
+        isImage: true,
+      ),
     ];
   }
 
-  void _removeAttachmentAt(int index) {
-    if (index < 0 || index >= _attachedDocuments.length) {
+  void _removeAttachment(String localId) {
+    _didTouchAttachments = true;
+    _attachmentUploadCoordinator.remove(localId);
+  }
+
+  Future<void> _retryAttachment(String localId) async {
+    _didTouchAttachments = true;
+    await _attachmentUploadCoordinator.retry(localId);
+  }
+
+  void _handleAttachmentUploadsChanged() {
+    if (!mounted) {
       return;
     }
+    setState(() {});
+  }
 
-    setState(() {
-      _attachedDocuments.removeAt(index);
-      _didTouchAttachments = true;
-    });
+  String _buildAttachmentLocalId({required String fileName, int? index}) {
+    final suffix = index == null ? '' : '_$index';
+    return '${DateTime.now().microsecondsSinceEpoch}${suffix}_$fileName';
+  }
+
+  bool _isImageFile(String fileName) {
+    final normalized = fileName.toLowerCase();
+    return normalized.endsWith('.jpg') ||
+        normalized.endsWith('.jpeg') ||
+        normalized.endsWith('.png') ||
+        normalized.endsWith('.webp');
   }
 
   String _resolveEventType(String title) {
@@ -1078,12 +1091,9 @@ class _AddEventPageState extends State<AddEventPage> {
             onPickFollowUpDate: _pickFollowUpDate,
             descriptionController: _descriptionController,
             onAddAttachment: _pickAndUploadAttachment,
-            attachmentNames: _attachedDocuments
-                .map((attachment) => attachment.fileName)
-                .toList(growable: false),
-            onRemoveAttachment: _removeAttachmentAt,
-            isUploadingAttachments:
-                _isUploadingAttachments || _isLoadingExistingAttachments,
+            attachments: _attachmentUploadCoordinator.items,
+            onRemoveAttachment: _removeAttachment,
+            onRetryAttachment: _retryAttachment,
           ),
         ];
       case 2:
@@ -1100,7 +1110,7 @@ class _AddEventPageState extends State<AddEventPage> {
             clinicController: _clinicController,
             followUpDateController: _followUpDateController,
             descriptionController: _descriptionController,
-            attachmentNames: _attachedDocuments
+            attachmentNames: _attachmentUploadCoordinator.items
                 .map((attachment) => attachment.fileName)
                 .toList(growable: false),
           ),

--- a/lib/presentation/pages/add_event/widgets/add_event_step_details.dart
+++ b/lib/presentation/pages/add_event/widgets/add_event_step_details.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_frontend/core/constants/app_strings.dart';
 import 'package:flutter_frontend/core/forms/app_form_constraints.dart';
 import 'package:flutter_frontend/core/forms/app_form_utils.dart';
+import 'package:flutter_frontend/core/models/attachment_models.dart';
 import 'package:flutter_frontend/presentation/pages/add_flow/widgets/add_flow_attachments.dart';
 import 'package:flutter_frontend/shared/widgets/form_field.dart';
 
@@ -17,9 +18,9 @@ class AddEventStepDetails extends StatelessWidget {
     required this.onPickFollowUpDate,
     required this.descriptionController,
     required this.onAddAttachment,
-    required this.attachmentNames,
+    required this.attachments,
     required this.onRemoveAttachment,
-    required this.isUploadingAttachments,
+    this.onRetryAttachment,
   });
 
   final TextEditingController eventController;
@@ -30,9 +31,9 @@ class AddEventStepDetails extends StatelessWidget {
   final VoidCallback onPickFollowUpDate;
   final TextEditingController descriptionController;
   final VoidCallback onAddAttachment;
-  final List<String> attachmentNames;
-  final ValueChanged<int> onRemoveAttachment;
-  final bool isUploadingAttachments;
+  final List<AttachmentUploadItem> attachments;
+  final ValueChanged<String> onRemoveAttachment;
+  final ValueChanged<String>? onRetryAttachment;
 
   bool _isValidDate(String value) {
     final parts = value.split('/');
@@ -142,9 +143,9 @@ class AddEventStepDetails extends StatelessWidget {
         const SizedBox(height: 18),
         AddFlowAttachmentsSection(
           onTap: onAddAttachment,
-          attachments: attachmentNames,
+          attachments: attachments,
           onRemoveAttachment: onRemoveAttachment,
-          isUploading: isUploadingAttachments,
+          onRetryAttachment: onRetryAttachment,
         ),
       ],
     );

--- a/lib/presentation/pages/add_flow/widgets/add_flow_attachments.dart
+++ b/lib/presentation/pages/add_flow/widgets/add_flow_attachments.dart
@@ -1,25 +1,29 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_frontend/core/constants/app_colors.dart';
 import 'package:flutter_frontend/core/constants/app_strings.dart';
+import 'package:flutter_frontend/core/models/attachment_models.dart';
 
 class AddFlowAttachmentsSection extends StatelessWidget {
   const AddFlowAttachmentsSection({
     super.key,
     this.onTap,
-    this.attachments = const <String>[],
+    this.attachments = const <AttachmentUploadItem>[],
     this.onRemoveAttachment,
-    this.isUploading = false,
+    this.onRetryAttachment,
   });
 
   final VoidCallback? onTap;
-  final List<String> attachments;
-  final ValueChanged<int>? onRemoveAttachment;
-  final bool isUploading;
+  final List<AttachmentUploadItem> attachments;
+  final ValueChanged<String>? onRemoveAttachment;
+  final ValueChanged<String>? onRetryAttachment;
 
   @override
   Widget build(BuildContext context) {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final hasAttachments = attachments.isNotEmpty;
+    final hasPendingUploads = attachments.any(
+      (attachment) => attachment.isPending,
+    );
     final titleColor = isDark ? AppColors.onSurfaceDark : AppColors.onSurface;
     final uploadBackground = isDark
         ? AppColors.quickActionIconBackgroundDark
@@ -50,7 +54,7 @@ class AddFlowAttachmentsSection extends StatelessWidget {
         const SizedBox(height: 12),
         Center(
           child: InkWell(
-            onTap: isUploading ? null : onTap,
+            onTap: hasPendingUploads ? null : onTap,
             borderRadius: BorderRadius.circular(24),
             child: Container(
               width: 140,
@@ -63,7 +67,7 @@ class AddFlowAttachmentsSection extends StatelessWidget {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  isUploading
+                  hasPendingUploads
                       ? const SizedBox(
                           width: 34,
                           height: 34,
@@ -76,7 +80,9 @@ class AddFlowAttachmentsSection extends StatelessWidget {
                         ),
                   const SizedBox(height: 8),
                   Text(
-                    AppStrings.uploadDocuments,
+                    hasPendingUploads
+                        ? 'Uploading...'
+                        : AppStrings.uploadDocuments,
                     textAlign: TextAlign.center,
                     style: TextStyle(
                       fontSize: 12,
@@ -103,7 +109,8 @@ class AddFlowAttachmentsSection extends StatelessWidget {
         if (hasAttachments) ...[
           const SizedBox(height: 14),
           ...List.generate(attachments.length, (index) {
-            final fileName = attachments[index];
+            final attachment = attachments[index];
+            final status = _statusMetadata(attachment.status, isDark: isDark);
             return Padding(
               padding: const EdgeInsets.only(bottom: 8),
               child: Container(
@@ -118,24 +125,51 @@ class AddFlowAttachmentsSection extends StatelessWidget {
                 ),
                 child: Row(
                   children: [
-                    Icon(
-                      Icons.insert_drive_file_outlined,
-                      size: 18,
-                      color: helperColor,
-                    ),
+                    Icon(status.icon, size: 18, color: status.color),
                     const SizedBox(width: 10),
                     Expanded(
-                      child: Text(
-                        fileName,
-                        maxLines: 1,
-                        overflow: TextOverflow.ellipsis,
-                        style: TextStyle(color: attachmentText),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            attachment.fileName,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(color: attachmentText),
+                          ),
+                          const SizedBox(height: 2),
+                          Text(
+                            status.label,
+                            style: TextStyle(
+                              color: status.color,
+                              fontSize: 12,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                          if (attachment.errorMessage != null &&
+                              attachment.errorMessage!.trim().isNotEmpty)
+                            Text(
+                              attachment.errorMessage!,
+                              maxLines: 2,
+                              overflow: TextOverflow.ellipsis,
+                              style: TextStyle(
+                                color: helperColor,
+                                fontSize: 11,
+                              ),
+                            ),
+                        ],
                       ),
                     ),
+                    if (attachment.isFailed && onRetryAttachment != null)
+                      IconButton(
+                        onPressed: () => onRetryAttachment!(attachment.localId),
+                        icon: Icon(Icons.refresh_rounded, color: helperColor),
+                        tooltip: 'Retry attachment',
+                      ),
                     IconButton(
                       onPressed: onRemoveAttachment == null
                           ? null
-                          : () => onRemoveAttachment!(index),
+                          : () => onRemoveAttachment!(attachment.localId),
                       icon: Icon(Icons.close_rounded, color: helperColor),
                       tooltip: 'Remove attachment',
                     ),
@@ -148,4 +182,55 @@ class AddFlowAttachmentsSection extends StatelessWidget {
       ],
     );
   }
+}
+
+class _AttachmentStatusMetadata {
+  const _AttachmentStatusMetadata({
+    required this.icon,
+    required this.color,
+    required this.label,
+  });
+
+  final IconData icon;
+  final Color color;
+  final String label;
+}
+
+_AttachmentStatusMetadata _statusMetadata(
+  AttachmentUploadStatus status, {
+  required bool isDark,
+}) {
+  final successColor = isDark ? AppColors.positiveTextDark : AppColors.success;
+  final warningColor = isDark
+      ? AppColors.smartAlertWarningTextDark
+      : AppColors.warning;
+  final errorColor = isDark ? AppColors.negativeTextDark : AppColors.error;
+
+  return switch (status) {
+    AttachmentUploadStatus.queued => _AttachmentStatusMetadata(
+      icon: Icons.schedule_rounded,
+      color: warningColor,
+      label: 'Queued',
+    ),
+    AttachmentUploadStatus.processing => _AttachmentStatusMetadata(
+      icon: Icons.tune_rounded,
+      color: warningColor,
+      label: 'Preparing',
+    ),
+    AttachmentUploadStatus.uploading => _AttachmentStatusMetadata(
+      icon: Icons.cloud_upload_outlined,
+      color: warningColor,
+      label: 'Uploading',
+    ),
+    AttachmentUploadStatus.succeeded => _AttachmentStatusMetadata(
+      icon: Icons.check_circle_outline_rounded,
+      color: successColor,
+      label: 'Uploaded',
+    ),
+    AttachmentUploadStatus.failed => _AttachmentStatusMetadata(
+      icon: Icons.error_outline_rounded,
+      color: errorColor,
+      label: 'Failed',
+    ),
+  };
 }

--- a/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
+++ b/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter_frontend/core/constants/app_colors.dart';
@@ -634,10 +636,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       }
 
       _didTouchAttachments = true;
-      await _attachmentUploadCoordinator.enqueueUploads(
-        petId: petId,
-        uploads: uploads,
-      );
+      _startAttachmentUploads(petId: petId, uploads: uploads);
     } catch (_) {
       if (!mounted) {
         return;
@@ -646,6 +645,30 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
         context,
       ).showSnackBar(const SnackBar(content: Text(AppStrings.errorGeneric)));
     }
+  }
+
+  void _startAttachmentUploads({
+    required String petId,
+    required List<PendingAttachmentUpload> uploads,
+  }) {
+    unawaited(
+      _attachmentUploadCoordinator
+          .enqueueUploads(petId: petId, uploads: uploads)
+          .then((_) {
+            if (!mounted) {
+              return;
+            }
+            setState(() {});
+          })
+          .catchError((_) {
+            if (!mounted) {
+              return;
+            }
+            ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text(AppStrings.errorGeneric)),
+            );
+          }),
+    );
   }
 
   Future<_AttachmentSource?> _showAttachmentSourcePicker() {

--- a/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
+++ b/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
@@ -6,7 +6,7 @@ import 'package:flutter_frontend/core/forms/app_form_utils.dart';
 import 'package:flutter_frontend/core/models/attachment_models.dart';
 import 'package:flutter_frontend/core/models/pet_model.dart';
 import 'package:flutter_frontend/core/models/vaccine_model.dart';
-import 'package:flutter_frontend/core/services/attachment_upload_service.dart';
+import 'package:flutter_frontend/core/services/attachment_upload_coordinator.dart';
 import 'package:flutter_frontend/core/services/pet_service.dart';
 import 'package:flutter_frontend/core/services/vaccine_service.dart';
 import 'package:image_picker/image_picker.dart';
@@ -38,18 +38,15 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
   final VaccineService _vaccineService = VaccineService();
   final PetService _petService = PetService();
-  final AttachmentUploadService _attachmentUploadService =
-      AttachmentUploadService();
+  final AttachmentUploadCoordinator _attachmentUploadCoordinator =
+      AttachmentUploadCoordinator();
   final ImagePicker _imagePicker = ImagePicker();
   final List<VaccineModel> _vaccines = [];
   final List<PetModel> _pets = [];
-  final List<EditableAttachmentModel> _attachedDocuments = [];
 
   bool _isLoadingVaccines = false;
   bool _isLoadingPets = false;
   bool _isSubmitting = false;
-  bool _isUploadingAttachments = false;
-  bool _isLoadingExistingAttachments = false;
   bool _didHydrateExistingAttachments = false;
   bool _didTouchAttachments = false;
   String? _selectedVaccineName;
@@ -65,6 +62,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
   @override
   void initState() {
     super.initState();
+    _attachmentUploadCoordinator.addListener(_handleAttachmentUploadsChanged);
     _applyPrefill(widget.prefill);
     _loadVaccines();
     _loadPets();
@@ -73,6 +71,10 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
   @override
   void dispose() {
+    _attachmentUploadCoordinator.removeListener(
+      _handleAttachmentUploadsChanged,
+    );
+    _attachmentUploadCoordinator.dispose();
     _dateController.dispose();
     _vaccineController.dispose();
     _productController.dispose();
@@ -108,18 +110,18 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       _editingVaccinationId = prefill.vaccinationId!.trim();
     }
 
-    _attachedDocuments
-      ..clear()
-      ..addAll(
-        (prefill.attachedDocuments ?? const <PetDocumentModel>[]).map(
-          (document) => EditableAttachmentModel(
-            fileName: document.fileName,
-            fileUri: document.fileUri,
-            documentId: document.documentId,
-          ),
-        ),
-      );
-    _didHydrateExistingAttachments = _attachedDocuments.isNotEmpty;
+    final existingAttachments =
+        (prefill.attachedDocuments ?? const <PetDocumentModel>[])
+            .map(
+              (document) => EditableAttachmentModel(
+                fileName: document.fileName,
+                fileUri: document.fileUri,
+                documentId: document.documentId,
+              ),
+            )
+            .toList(growable: false);
+    _attachmentUploadCoordinator.initializeFromExisting(existingAttachments);
+    _didHydrateExistingAttachments = existingAttachments.isNotEmpty;
 
     if (_vaccines.isNotEmpty) {
       _applyVaccineSelectionFromPrefill(prefill);
@@ -141,12 +143,6 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     }
 
     try {
-      if (mounted) {
-        setState(() {
-          _isLoadingExistingAttachments = true;
-        });
-      }
-
       final vaccination = await _petService.getVaccination(
         petId: petId,
         vaccinationId: vaccinationId,
@@ -161,27 +157,21 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
           _administeredByController.text = vaccination.administeredBy.trim();
         }
 
-        _attachedDocuments
-          ..clear()
-          ..addAll(
-            vaccination.attachedDocuments.map(
-              (document) => EditableAttachmentModel(
-                fileName: document.fileName,
-                fileUri: document.fileUri,
-                documentId: document.documentId,
-              ),
-            ),
-          );
+        _attachmentUploadCoordinator.initializeFromExisting(
+          vaccination.attachedDocuments
+              .map(
+                (document) => EditableAttachmentModel(
+                  fileName: document.fileName,
+                  fileUri: document.fileUri,
+                  documentId: document.documentId,
+                ),
+              )
+              .toList(growable: false),
+        );
         _didHydrateExistingAttachments = true;
       });
     } catch (_) {
       // Keep the form usable even if hydration fails.
-    } finally {
-      if (mounted) {
-        setState(() {
-          _isLoadingExistingAttachments = false;
-        });
-      }
     }
   }
 
@@ -505,6 +495,17 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       return;
     }
 
+    if (!_attachmentUploadCoordinator.canSubmit) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(
+          content: Text(
+            'Finish uploading or remove failed attachments before saving.',
+          ),
+        ),
+      );
+      return;
+    }
+
     final dateGiven = parseDateInput(_dateController.text.trim());
     if (dateGiven == null) {
       ScaffoldMessenger.of(
@@ -563,7 +564,8 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
         'status': 'completed',
         'administeredBy': _administeredByController.text.trim(),
         'clinicName': '',
-        'attachedDocuments': _attachedDocuments
+        'attachedDocuments': _attachmentUploadCoordinator
+            .buildSucceededPayload()
             .map((attachment) => attachment.toPayload())
             .toList(growable: false),
       };
@@ -623,18 +625,19 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       }
 
       final uploads = switch (source) {
-        _AttachmentSource.files => await _pickFilesForAttachment(petId),
-        _AttachmentSource.camera => await _capturePhotoForAttachment(petId),
+        _AttachmentSource.files => await _pickFilesForAttachment(),
+        _AttachmentSource.camera => await _capturePhotoForAttachment(),
       };
 
       if (uploads.isEmpty || !mounted) {
         return;
       }
 
-      setState(() {
-        _attachedDocuments.addAll(uploads);
-        _didTouchAttachments = true;
-      });
+      _didTouchAttachments = true;
+      await _attachmentUploadCoordinator.enqueueUploads(
+        petId: petId,
+        uploads: uploads,
+      );
     } catch (_) {
       if (!mounted) {
         return;
@@ -642,10 +645,6 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       ScaffoldMessenger.of(
         context,
       ).showSnackBar(const SnackBar(content: Text(AppStrings.errorGeneric)));
-    } finally {
-      if (mounted) {
-        setState(() => _isUploadingAttachments = false);
-      }
     }
   }
 
@@ -679,9 +678,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     );
   }
 
-  Future<List<EditableAttachmentModel>> _pickFilesForAttachment(
-    String petId,
-  ) async {
+  Future<List<PendingAttachmentUpload>> _pickFilesForAttachment() async {
     final result = await FilePicker.platform.pickFiles(
       allowMultiple: true,
       withData: true,
@@ -690,37 +687,36 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     );
 
     if (result == null || result.files.isEmpty) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     if (!mounted) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
-    setState(() => _isUploadingAttachments = true);
-
-    final uploads = <EditableAttachmentModel>[];
-    for (final file in result.files) {
+    final uploads = <PendingAttachmentUpload>[];
+    for (var index = 0; index < result.files.length; index++) {
+      final file = result.files[index];
       final bytes = file.bytes;
       if (bytes == null || bytes.isEmpty) {
         continue;
       }
 
-      final uploaded = await _attachmentUploadService.uploadPetDocument(
-        bytes: bytes,
-        petId: petId,
-        fileName: file.name,
-        category: 'vaccinations',
+      uploads.add(
+        PendingAttachmentUpload(
+          localId: _buildAttachmentLocalId(fileName: file.name, index: index),
+          fileName: file.name,
+          bytes: bytes,
+          category: 'vaccinations',
+          isImage: _isImageFile(file.name),
+        ),
       );
-      uploads.add(EditableAttachmentModel.fromUploaded(uploaded));
     }
 
     return uploads;
   }
 
-  Future<List<EditableAttachmentModel>> _capturePhotoForAttachment(
-    String petId,
-  ) async {
+  Future<List<PendingAttachmentUpload>> _capturePhotoForAttachment() async {
     final photo = await _imagePicker.pickImage(
       source: ImageSource.camera,
       imageQuality: 85,
@@ -729,41 +725,57 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     );
 
     if (photo == null) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     final bytes = await photo.readAsBytes();
     if (bytes.isEmpty) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
     if (!mounted) {
-      return const <EditableAttachmentModel>[];
+      return const <PendingAttachmentUpload>[];
     }
 
-    setState(() => _isUploadingAttachments = true);
-
-    final uploaded = await _attachmentUploadService.uploadPetDocument(
-      bytes: bytes,
-      petId: petId,
-      fileName: photo.name,
-      category: 'vaccinations',
-    );
-
-    return <EditableAttachmentModel>[
-      EditableAttachmentModel.fromUploaded(uploaded),
+    return <PendingAttachmentUpload>[
+      PendingAttachmentUpload(
+        localId: _buildAttachmentLocalId(fileName: photo.name),
+        fileName: photo.name,
+        bytes: bytes,
+        category: 'vaccinations',
+        isImage: true,
+      ),
     ];
   }
 
-  void _removeAttachmentAt(int index) {
-    if (index < 0 || index >= _attachedDocuments.length) {
+  void _removeAttachment(String localId) {
+    _didTouchAttachments = true;
+    _attachmentUploadCoordinator.remove(localId);
+  }
+
+  Future<void> _retryAttachment(String localId) async {
+    _didTouchAttachments = true;
+    await _attachmentUploadCoordinator.retry(localId);
+  }
+
+  void _handleAttachmentUploadsChanged() {
+    if (!mounted) {
       return;
     }
+    setState(() {});
+  }
 
-    setState(() {
-      _attachedDocuments.removeAt(index);
-      _didTouchAttachments = true;
-    });
+  String _buildAttachmentLocalId({required String fileName, int? index}) {
+    final suffix = index == null ? '' : '_$index';
+    return '${DateTime.now().microsecondsSinceEpoch}${suffix}_$fileName';
+  }
+
+  bool _isImageFile(String fileName) {
+    final normalized = fileName.toLowerCase();
+    return normalized.endsWith('.jpg') ||
+        normalized.endsWith('.jpeg') ||
+        normalized.endsWith('.png') ||
+        normalized.endsWith('.webp');
   }
 
   @override
@@ -882,12 +894,9 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
           AddVaccineStepDetails(
             administeredByController: _administeredByController,
             onAddAttachment: _pickAndUploadAttachment,
-            attachmentNames: _attachedDocuments
-                .map((attachment) => attachment.fileName)
-                .toList(growable: false),
-            onRemoveAttachment: _removeAttachmentAt,
-            isUploadingAttachments:
-                _isUploadingAttachments || _isLoadingExistingAttachments,
+            attachments: _attachmentUploadCoordinator.items,
+            onRemoveAttachment: _removeAttachment,
+            onRetryAttachment: _retryAttachment,
           ),
         ];
       case 2:
@@ -899,7 +908,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
             productController: _productController,
             petNameController: _petNameController,
             administeredByController: _administeredByController,
-            attachmentNames: _attachedDocuments
+            attachmentNames: _attachmentUploadCoordinator.items
                 .map((attachment) => attachment.fileName)
                 .toList(growable: false),
           ),

--- a/lib/presentation/pages/add_vaccine/widgets/add_vaccine_step_details.dart
+++ b/lib/presentation/pages/add_vaccine/widgets/add_vaccine_step_details.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_frontend/core/constants/app_strings.dart';
 import 'package:flutter_frontend/core/forms/app_form_constraints.dart';
 import 'package:flutter_frontend/core/forms/app_form_utils.dart';
+import 'package:flutter_frontend/core/models/attachment_models.dart';
 import 'package:flutter_frontend/presentation/pages/add_flow/widgets/add_flow_attachments.dart';
 import 'package:flutter_frontend/shared/widgets/form_field.dart';
 
@@ -11,16 +12,16 @@ class AddVaccineStepDetails extends StatelessWidget {
     super.key,
     required this.administeredByController,
     required this.onAddAttachment,
-    required this.attachmentNames,
+    required this.attachments,
     required this.onRemoveAttachment,
-    required this.isUploadingAttachments,
+    this.onRetryAttachment,
   });
 
   final TextEditingController administeredByController;
   final VoidCallback onAddAttachment;
-  final List<String> attachmentNames;
-  final ValueChanged<int> onRemoveAttachment;
-  final bool isUploadingAttachments;
+  final List<AttachmentUploadItem> attachments;
+  final ValueChanged<String> onRemoveAttachment;
+  final ValueChanged<String>? onRetryAttachment;
 
   @override
   Widget build(BuildContext context) {
@@ -44,9 +45,9 @@ class AddVaccineStepDetails extends StatelessWidget {
         const SizedBox(height: 18),
         AddFlowAttachmentsSection(
           onTap: onAddAttachment,
-          attachments: attachmentNames,
+          attachments: attachments,
           onRemoveAttachment: onRemoveAttachment,
-          isUploading: isUploadingAttachments,
+          onRetryAttachment: onRetryAttachment,
         ),
       ],
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   google_sign_in: ^6.2.1
   http: ^1.6.0
   image_picker: ^1.1.2
+  image: ^4.5.4
   nfc_manager: ^4.1.1
   open_filex: ^4.7.0
   path_provider: ^2.1.1


### PR DESCRIPTION
**Description**
This PR instruments attachment uploads so the app can answer the Type 1 business question through the existing analytics pipeline.

**Changes**
- Add telemetry IDs for vaccine and event attachment uploads
- Log one feature execution event per successful uploaded file
- Capture startTime, endTime, 	otalTime, uploadSpeed, and ppType
- Integrate upload telemetry into the attachment upload coordinator
- Use real analytics feature IDs created in the backend

**Why**
This allows upload latency data to be captured from Flutter, stored in the backend telemetry pipeline, and later analyzed from the database in Power BI.