### PR TITLE
Add internet notice to smart alerts

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -364,6 +364,8 @@ abstract class AppStrings {
   static const String smartAlertsFilterAll = 'All';
   static const String smartAlertsEmpty =
       'No health alerts available right now.';
+  static const String smartAlertsInternetNotice =
+      'For new notifications please connect to internet.';
   static const String smartAlertsShowLess = 'Show less';
 
   // --- Welcome pages ---

--- a/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
+++ b/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
@@ -159,37 +159,47 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
     }
 
     if (_errorMessage != null) {
-      return Center(
-        child: Padding(
-          padding: const EdgeInsets.all(AppDimensions.spaceXL),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              const Icon(
-                Icons.cloud_off_rounded,
-                size: 56,
-                color: AppColors.grey300,
+      return Column(
+        children: [
+          const SizedBox(height: AppDimensions.spaceS),
+          _buildInternetNotice(),
+          Expanded(
+            child: Center(
+              child: Padding(
+                padding: const EdgeInsets.all(AppDimensions.spaceXL),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    const Icon(
+                      Icons.cloud_off_rounded,
+                      size: 56,
+                      color: AppColors.grey300,
+                    ),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    Text(
+                      _errorMessage!,
+                      textAlign: TextAlign.center,
+                      style: const TextStyle(color: AppColors.grey700),
+                    ),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    OutlinedButton(
+                      onPressed: _loadAlerts,
+                      child: const Text(AppStrings.petsRetry),
+                    ),
+                  ],
+                ),
               ),
-              const SizedBox(height: AppDimensions.spaceM),
-              Text(
-                _errorMessage!,
-                textAlign: TextAlign.center,
-                style: const TextStyle(color: AppColors.grey700),
-              ),
-              const SizedBox(height: AppDimensions.spaceM),
-              OutlinedButton(
-                onPressed: _loadAlerts,
-                child: const Text(AppStrings.petsRetry),
-              ),
-            ],
+            ),
           ),
-        ),
+        ],
       );
     }
 
     return Column(
       children: [
         const SizedBox(height: AppDimensions.spaceS),
+        _buildInternetNotice(),
+        const SizedBox(height: AppDimensions.spaceM),
         _buildFilterBar(),
         const SizedBox(height: AppDimensions.spaceM),
         Expanded(
@@ -219,6 +229,44 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
                 ),
         ),
       ],
+    );
+  }
+
+  Widget _buildInternetNotice() {
+    return Container(
+      width: double.infinity,
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.pageHorizontalPadding,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.spaceM,
+        vertical: AppDimensions.spaceM,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.smartAlertInfoBg,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: const Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.wifi_off_rounded,
+            color: AppColors.smartAlertInfoText,
+            size: 20,
+          ),
+          SizedBox(width: AppDimensions.spaceS),
+          Expanded(
+            child: Text(
+              AppStrings.smartAlertsInternetNotice,
+              style: TextStyle(
+                color: AppColors.smartAlertInfoText,
+                fontSize: 13,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
     );
   }
 


### PR DESCRIPTION
**Title**  
\Add internet notice to smart alerts\

**Description**  
This PR adds a simple notice to the smart alerts screen to clarify that new notifications require an internet connection.

**Changes**
- Add a new smart alerts notice string
- Show the internet notice at the top of the smart alerts screen
- Keep the notice visible when alerts fail to load

**Why**
Smart alerts now rely on cache when offline, but new notifications are not generated without internet. This message makes that behavior clear to users.

**Validation**
- \dart format\ applied
- \lutter analyze\ passes