### PR TITLE
Fix add vaccine prefill create mode

### DIFF
--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -262,9 +262,10 @@ class PetService {
   }) async {
     final normalizedPetId = petId.trim();
     try {
+      final apiData = await _prepareVaccinationPayloadForApi(data);
       final response = await _apiClient.post(
         '$petsPath$normalizedPetId/vaccinations/',
-        body: data,
+        body: apiData,
       );
 
       if (response.body.trim().isNotEmpty) {
@@ -278,7 +279,8 @@ class PetService {
       }
       await _invalidatePetsCache();
     } catch (error) {
-      if (!_shouldQueueOffline(error)) {
+      if (!_shouldQueueOffline(error) &&
+          !_shouldQueuePendingAttachmentResolution(error, data)) {
         rethrow;
       }
 
@@ -327,9 +329,10 @@ class PetService {
     }
 
     try {
+      final apiData = await _prepareVaccinationPayloadForApi(data);
       await _apiClient.put(
         '$petsPath$normalizedPetId/vaccinations/$normalizedVaccinationId/',
-        body: data,
+        body: apiData,
       );
 
       final current =
@@ -341,7 +344,7 @@ class PetService {
             'id': normalizedVaccinationId,
             'petId': normalizedPetId,
           };
-      final merged = <String, dynamic>{...current, ..._asPetMap(data)};
+      final merged = <String, dynamic>{...current, ..._asPetMap(apiData)};
       merged['id'] = normalizedVaccinationId;
       merged['petId'] = normalizedPetId;
       await _localDb.upsertEntity(
@@ -355,7 +358,8 @@ class PetService {
       );
       await _invalidatePetsCache();
     } catch (error) {
-      if (!_shouldQueueOffline(error)) {
+      if (!_shouldQueueOffline(error) &&
+          !_shouldQueuePendingAttachmentResolution(error, data)) {
         rethrow;
       }
 
@@ -764,6 +768,63 @@ class PetService {
 
   bool _shouldQueueOffline(Object error) {
     return error is ApiException && error.type == ApiErrorType.network;
+  }
+
+  bool _shouldQueuePendingAttachmentResolution(
+    Object error,
+    Map<String, dynamic> data,
+  ) {
+    final message = error.toString();
+    return message.contains('Attachment upload still pending') &&
+        _hasPendingAttachmentUpload(data);
+  }
+
+  bool _hasPendingAttachmentUpload(Map<String, dynamic> data) {
+    final documents = data['attachedDocuments'];
+    if (documents is! List) {
+      return false;
+    }
+
+    return documents.map(_asPetMap).any((document) {
+      return document['pendingUpload'] == true ||
+          ((document['fileUri'] as String?)?.trim().isEmpty ?? true) &&
+              ((document['storagePath'] as String?)?.trim().isNotEmpty ??
+                  false);
+    });
+  }
+
+  Future<Map<String, dynamic>> _prepareVaccinationPayloadForApi(
+    Map<String, dynamic> data,
+  ) async {
+    final resolved = await _attachmentUploadService
+        .resolvePendingAttachmentsInPayload(_asPetMap(data));
+    return _sanitizeAttachmentPayloadForApi(resolved);
+  }
+
+  Map<String, dynamic> _sanitizeAttachmentPayloadForApi(
+    Map<String, dynamic> payload,
+  ) {
+    final documents = payload['attachedDocuments'];
+    if (documents is! List) {
+      return payload;
+    }
+
+    return <String, dynamic>{
+      ...payload,
+      'attachedDocuments': documents
+          .map(_sanitizeDocumentForApi)
+          .toList(growable: false),
+    };
+  }
+
+  Map<String, dynamic> _sanitizeDocumentForApi(dynamic value) {
+    final document = _asPetMap(value);
+    return <String, dynamic>{
+      if ((document['documentId'] as String?)?.trim().isNotEmpty == true)
+        'documentId': (document['documentId'] as String).trim(),
+      'fileName': ((document['fileName'] as String?) ?? '').trim(),
+      'fileUri': ((document['fileUri'] as String?) ?? '').trim(),
+    };
   }
 
   String _newLocalId(String prefix) {

--- a/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
+++ b/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
@@ -61,6 +61,9 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
   int _step = 0;
 
+  bool get _isEditingVaccination =>
+      _editingVaccinationId != null && _editingVaccinationId!.trim().isNotEmpty;
+
   @override
   void initState() {
     super.initState();
@@ -523,15 +526,13 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     setState(() => _isSubmitting = true);
 
     try {
-      if (_editingVaccinationId != null &&
-          _editingVaccinationId!.trim().isNotEmpty &&
+      if (_isEditingVaccination &&
           !_didTouchAttachments &&
           !_didHydrateExistingAttachments) {
         await _loadEditingVaccinationIfNeeded(force: true);
       }
 
-      if (_editingVaccinationId != null &&
-          _editingVaccinationId!.trim().isNotEmpty &&
+      if (_isEditingVaccination &&
           !_didTouchAttachments &&
           !_didHydrateExistingAttachments) {
         if (!mounted) {
@@ -572,13 +573,9 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
             .toList(growable: false),
       };
 
-      if (widget.prefill == null) {
+      if (!_isEditingVaccination) {
         await _petService.addVaccination(petId: _selectedPetId!, data: payload);
       } else {
-        if (_editingVaccinationId == null ||
-            _editingVaccinationId!.trim().isEmpty) {
-          throw Exception('Missing vaccination id for update.');
-        }
         await _petService.updateVaccination(
           petId: _selectedPetId!,
           vaccinationId: _editingVaccinationId!,
@@ -591,7 +588,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            widget.prefill == null
+            !_isEditingVaccination
                 ? 'Vaccine saved successfully.'
                 : 'Vaccine updated successfully.',
           ),
@@ -826,7 +823,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
       currentStep: _step,
       stepContent: _buildStepContent(),
       primaryButtonText: _step == 2
-          ? (widget.prefill == null
+          ? (!_isEditingVaccination
                 ? AppStrings.semanticAddVaccineButton
                 : AppStrings.semanticUpdateVaccineButton)
           : AppStrings.semanticContinueButton,


### PR DESCRIPTION
## Summary
- Treat Add Vaccine as edit mode only when a vaccination id is present
- Keep Pet Detail pet prefill in create mode so the button says Add Vaccine and saves a new record
- Resolve and sanitize vaccination attached documents before sending create/update payloads

## Validation
- flutter analyze

Closes #105