### PR TITLE
offline mode bugs fix

### DIFF
--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -357,6 +357,10 @@ abstract class AppStrings {
   static const String petLostConfirmAction = 'Mark Lost';
   static const String petMarkedAsLostMessage = 'Pet marked as lost.';
   static const String petMarkedAsFoundMessage = 'Pet marked as found.';
+  static const String petMarkedAsLostOfflineMessage =
+      'Lost mode saved offline. It will sync when you reconnect.';
+  static const String petMarkedAsFoundOfflineMessage =
+      'Found status saved offline. It will sync when you reconnect.';
   static const String petDetailShareSemantics = 'Share pet';
   static const String petDetailEditSemantics = 'Edit pet';
   static const String petDetailMoreSemantics = 'More options';

--- a/lib/core/services/attachment_upload_service.dart
+++ b/lib/core/services/attachment_upload_service.dart
@@ -195,7 +195,10 @@ class AttachmentUploadService {
         storagePath: storagePath,
         contentType: contentType,
       );
-      await _rememberUploadMapping(storagePath: storagePath, downloadUrl: downloadUrl);
+      await _rememberUploadMapping(
+        storagePath: storagePath,
+        downloadUrl: downloadUrl,
+      );
 
       if (localFilePath != null && localFilePath.trim().isNotEmpty) {
         try {
@@ -308,10 +311,25 @@ class AttachmentUploadService {
         final contentType = (payload['contentType'] as String?)?.trim() ?? '';
         final localPath = (payload['localFilePath'] as String?)?.trim() ?? '';
         final localCategory =
-            (payload['localCategory'] as String?)?.trim() ?? 'documents/general';
-        final localStableId = (payload['localStableId'] as String?)?.trim() ?? '';
+            (payload['localCategory'] as String?)?.trim() ??
+            'documents/general';
+        final localStableId =
+            (payload['localStableId'] as String?)?.trim() ?? '';
 
-        if (storagePath.isEmpty || localPath.isEmpty || fileName.isEmpty) {
+        if (storagePath.isEmpty) {
+          throw Exception('Invalid queued attachment payload.');
+        }
+
+        final existingDownloadUrl = await _localDb.getMetaValue(
+          _attachmentUrlMetaKey(storagePath),
+        );
+        if (existingDownloadUrl != null &&
+            existingDownloadUrl.trim().isNotEmpty) {
+          await _localDb.markSyncOperationCompleted(operation.id);
+          continue;
+        }
+
+        if (localPath.isEmpty || fileName.isEmpty) {
           throw Exception('Invalid queued attachment payload.');
         }
 
@@ -381,6 +399,70 @@ class AttachmentUploadService {
     return resolvedPayload;
   }
 
+  Future<String> resolvePendingUploadUrl({
+    required String storagePath,
+    required String localFilePath,
+    required String fileName,
+    String contentType = '',
+  }) async {
+    final normalizedStoragePath = storagePath.trim();
+    if (normalizedStoragePath.isEmpty) {
+      throw Exception('Attachment upload storage path is missing.');
+    }
+
+    final downloadUrl = await _localDb.getMetaValue(
+      _attachmentUrlMetaKey(normalizedStoragePath),
+    );
+    if (downloadUrl != null && downloadUrl.trim().isNotEmpty) {
+      return downloadUrl.trim();
+    }
+
+    final normalizedLocalFilePath = localFilePath.trim();
+    final normalizedFileName = fileName.trim();
+    if (normalizedLocalFilePath.isEmpty || normalizedFileName.isEmpty) {
+      throw Exception(
+        'Attachment upload still pending for storage path: $normalizedStoragePath',
+      );
+    }
+
+    final hasInternet = await _hasInternetAccess();
+    if (!hasInternet) {
+      throw Exception(
+        'Attachment upload still pending for storage path: $normalizedStoragePath',
+      );
+    }
+
+    final file = File(normalizedLocalFilePath);
+    if (!await file.exists()) {
+      throw Exception(
+        'Local attachment file was not found for queued upload: $normalizedLocalFilePath',
+      );
+    }
+
+    final bytes = await file.readAsBytes();
+    if (bytes.isEmpty) {
+      throw Exception(
+        'Local attachment file is empty for queued upload: $normalizedLocalFilePath',
+      );
+    }
+
+    final resolvedContentType = contentType.trim().isNotEmpty
+        ? contentType.trim()
+        : _contentTypeForFileName(normalizedFileName);
+    final uploadedUrl = await _uploadToFirebase(
+      bytes: bytes,
+      fileName: normalizedFileName,
+      storagePath: normalizedStoragePath,
+      contentType: resolvedContentType,
+    );
+    await _rememberUploadMapping(
+      storagePath: normalizedStoragePath,
+      downloadUrl: uploadedUrl,
+    );
+
+    return uploadedUrl;
+  }
+
   Future<Map<String, dynamic>> _resolvePendingDocument(
     Map<String, dynamic> document,
   ) async {
@@ -394,45 +476,16 @@ class AttachmentUploadService {
       return document;
     }
 
-    final downloadUrl = await _localDb.getMetaValue(
-      _attachmentUrlMetaKey(storagePath),
-    );
-    if (downloadUrl != null && downloadUrl.trim().isNotEmpty) {
-      return <String, dynamic>{...document, 'fileUri': downloadUrl.trim()};
-    }
-
     final localFilePath = (document['localFilePath'] as String?)?.trim() ?? '';
     final fileName = (document['fileName'] as String?)?.trim() ?? '';
-    if (localFilePath.isNotEmpty && fileName.isNotEmpty) {
-      final hasInternet = await _hasInternetAccess();
-      if (hasInternet) {
-        final file = File(localFilePath);
-        if (await file.exists()) {
-          final bytes = await file.readAsBytes();
-          if (bytes.isNotEmpty) {
-            final contentType =
-                (document['contentType'] as String?)?.trim().isNotEmpty == true
-                ? (document['contentType'] as String).trim()
-                : _contentTypeForFileName(fileName);
-            final uploadedUrl = await _uploadToFirebase(
-              bytes: bytes,
-              fileName: fileName,
-              storagePath: storagePath,
-              contentType: contentType,
-            );
-            await _rememberUploadMapping(
-              storagePath: storagePath,
-              downloadUrl: uploadedUrl,
-            );
-            return <String, dynamic>{...document, 'fileUri': uploadedUrl};
-          }
-        }
-      }
-    }
-
-    throw Exception(
-      'Attachment upload still pending for storage path: $storagePath',
+    final contentType = (document['contentType'] as String?)?.trim() ?? '';
+    final resolvedUrl = await resolvePendingUploadUrl(
+      storagePath: storagePath,
+      localFilePath: localFilePath,
+      fileName: fileName,
+      contentType: contentType,
     );
+    return <String, dynamic>{...document, 'fileUri': resolvedUrl};
   }
 
   bool _isRemoteHttpUrl(String value) {
@@ -472,7 +525,9 @@ class AttachmentUploadService {
 
     final downloadUrl = await ref.getDownloadURL().timeout(_uploadTimeout);
 
-    debugPrint('[AttachmentUploadService] download URL resolved path=$storagePath');
+    debugPrint(
+      '[AttachmentUploadService] download URL resolved path=$storagePath',
+    );
     return downloadUrl;
   }
 

--- a/lib/core/services/event_service.dart
+++ b/lib/core/services/event_service.dart
@@ -39,7 +39,9 @@ class EventService {
     final cacheKey = _eventsByPetCacheKey(trimmedPetId);
     final cachedEntry = await _cache.get(cacheKey);
 
-    if (!forceRefresh && cachedEntry != null && cachedEntry.isFresh(_eventsByPetCacheTtl)) {
+    if (!forceRefresh &&
+        cachedEntry != null &&
+        cachedEntry.isFresh(_eventsByPetCacheTtl)) {
       final cachedEvents = _tryParseEvents(cachedEntry.body);
       if (cachedEvents != null) {
         unawaited(_persistEventsFromBody(cachedEntry.body));
@@ -74,7 +76,8 @@ class EventService {
 
   Future<EventModel> createEvent(Map<String, dynamic> data) async {
     try {
-      final response = await _apiClient.post(eventsPath, body: data);
+      final apiData = await _prepareEventPayloadForApi(data);
+      final response = await _apiClient.post(eventsPath, body: apiData);
       final createdEvent = _decodeEventMap(
         response.body,
         fallbackMessage: 'Unexpected create event response.',
@@ -83,7 +86,8 @@ class EventService {
       await _invalidateEventsCache();
       return createdEvent;
     } catch (error) {
-      if (!_shouldQueueOffline(error)) {
+      if (!_shouldQueueOffline(error) &&
+          !_shouldQueuePendingAttachmentResolution(error, data)) {
         rethrow;
       }
 
@@ -138,9 +142,10 @@ class EventService {
   }) async {
     final trimmedEventId = eventId.trim();
     try {
+      final apiData = await _prepareEventPayloadForApi(data);
       final response = await _apiClient.put(
         '$eventsPath$trimmedEventId/',
-        body: data,
+        body: apiData,
       );
       final updatedEvent = _decodeEventMap(
         response.body,
@@ -150,7 +155,8 @@ class EventService {
       await _invalidateEventsCache();
       return updatedEvent;
     } catch (error) {
-      if (!_shouldQueueOffline(error)) {
+      if (!_shouldQueueOffline(error) &&
+          !_shouldQueuePendingAttachmentResolution(error, data)) {
         rethrow;
       }
 
@@ -161,7 +167,10 @@ class EventService {
           ) ??
           _buildPendingEventPayload(source: data, eventId: trimmedEventId);
 
-      final merged = <String, dynamic>{...current, ..._asStringDynamicMap(data)};
+      final merged = <String, dynamic>{
+        ...current,
+        ..._asStringDynamicMap(data),
+      };
       merged['id'] = trimmedEventId;
 
       await _localDb.upsertEntity(
@@ -221,12 +230,9 @@ class EventService {
             final createPayload = _asStringDynamicMap(
               operation.payload ?? const <String, dynamic>{},
             );
-            final resolvedAttachmentPayload = await _attachmentUploadService
-                .resolvePendingAttachmentsInPayload(createPayload);
-            final resolvedCreatePayload =
-                await _resolveEventPayloadPetIdForSync(
-                  resolvedAttachmentPayload,
-                );
+            final resolvedCreatePayload = await _prepareEventPayloadForApi(
+              createPayload,
+            );
             final response = await _apiClient.post(
               eventsPath,
               body: resolvedCreatePayload,
@@ -245,12 +251,9 @@ class EventService {
             final updatePayload = _asStringDynamicMap(
               operation.payload ?? const <String, dynamic>{},
             );
-            final resolvedAttachmentPayload = await _attachmentUploadService
-                .resolvePendingAttachmentsInPayload(updatePayload);
-            final resolvedUpdatePayload =
-                await _resolveEventPayloadPetIdForSync(
-                  resolvedAttachmentPayload,
-                );
+            final resolvedUpdatePayload = await _prepareEventPayloadForApi(
+              updatePayload,
+            );
             await _apiClient.put(
               '$eventsPath${operation.entityId}/',
               body: resolvedUpdatePayload,
@@ -324,14 +327,14 @@ class EventService {
     return '$_eventsByPetCachePrefix$petId';
   }
 
-  EventModel _decodeEventMap(String responseBody, {required String fallbackMessage}) {
+  EventModel _decodeEventMap(
+    String responseBody, {
+    required String fallbackMessage,
+  }) {
     final decoded = _decodeJson(responseBody);
 
     if (decoded is! Map<String, dynamic>) {
-      throw ApiException(
-        type: ApiErrorType.unknown,
-        message: fallbackMessage,
-      );
+      throw ApiException(type: ApiErrorType.unknown, message: fallbackMessage);
     }
 
     return EventModel.fromJson(decoded);
@@ -478,13 +481,52 @@ class EventService {
       return null;
     }
 
-    final mapped = await _localDb.getMetaValue('$_petIdMappingMetaPrefix$trimmed');
+    final mapped = await _localDb.getMetaValue(
+      '$_petIdMappingMetaPrefix$trimmed',
+    );
     final mappedTrimmed = mapped?.trim() ?? '';
     if (mappedTrimmed.isNotEmpty) {
       return mappedTrimmed;
     }
 
     return trimmed;
+  }
+
+  Future<Map<String, dynamic>> _prepareEventPayloadForApi(
+    Map<String, dynamic> data,
+  ) async {
+    final resolvedAttachments = await _attachmentUploadService
+        .resolvePendingAttachmentsInPayload(_asStringDynamicMap(data));
+    final resolvedPetId = await _resolveEventPayloadPetIdForSync(
+      resolvedAttachments,
+    );
+    return _sanitizeAttachmentPayloadForApi(resolvedPetId);
+  }
+
+  Map<String, dynamic> _sanitizeAttachmentPayloadForApi(
+    Map<String, dynamic> payload,
+  ) {
+    final documents = payload['attachedDocuments'];
+    if (documents is! List) {
+      return payload;
+    }
+
+    return <String, dynamic>{
+      ...payload,
+      'attachedDocuments': documents
+          .map(_sanitizeDocumentForApi)
+          .toList(growable: false),
+    };
+  }
+
+  Map<String, dynamic> _sanitizeDocumentForApi(dynamic value) {
+    final document = _asStringDynamicMap(value);
+    return <String, dynamic>{
+      if ((document['documentId'] as String?)?.trim().isNotEmpty == true)
+        'documentId': (document['documentId'] as String).trim(),
+      'fileName': ((document['fileName'] as String?) ?? '').trim(),
+      'fileUri': ((document['fileUri'] as String?) ?? '').trim(),
+    };
   }
 
   Map<String, dynamic> _eventToMap(EventModel event) {
@@ -517,6 +559,29 @@ class EventService {
     return error is ApiException && error.type == ApiErrorType.network;
   }
 
+  bool _shouldQueuePendingAttachmentResolution(
+    Object error,
+    Map<String, dynamic> data,
+  ) {
+    final message = error.toString();
+    return message.contains('Attachment upload still pending') &&
+        _hasPendingAttachmentUpload(data);
+  }
+
+  bool _hasPendingAttachmentUpload(Map<String, dynamic> data) {
+    final documents = data['attachedDocuments'];
+    if (documents is! List) {
+      return false;
+    }
+
+    return documents.map(_asStringDynamicMap).any((document) {
+      return document['pendingUpload'] == true ||
+          ((document['fileUri'] as String?)?.trim().isEmpty ?? true) &&
+              ((document['storagePath'] as String?)?.trim().isNotEmpty ??
+                  false);
+    });
+  }
+
   String _newLocalId(String prefix) {
     return 'local_${prefix}_${DateTime.now().millisecondsSinceEpoch}';
   }
@@ -539,7 +604,8 @@ class EventService {
       'clinic': map['clinic'] ?? '',
       'description': map['description'] ?? '',
       'followUpDate': map['followUpDate'] ?? map['follow_up_date'],
-      'attachedDocuments': map['attachedDocuments'] ??
+      'attachedDocuments':
+          map['attachedDocuments'] ??
           map['attached_documents'] ??
           const <dynamic>[],
     };

--- a/lib/core/services/local_database_service.dart
+++ b/lib/core/services/local_database_service.dart
@@ -201,6 +201,27 @@ class LocalDatabaseService {
     return null;
   }
 
+  Future<String?> getEntitySyncStatus({
+    required String table,
+    required String remoteId,
+  }) async {
+    final db = await database;
+    final rows = await db.query(
+      table,
+      columns: <String>['sync_status'],
+      where: 'remote_id = ?',
+      whereArgs: <Object>[remoteId],
+      limit: 1,
+    );
+
+    if (rows.isEmpty) {
+      return null;
+    }
+
+    final syncStatus = rows.first['sync_status'];
+    return syncStatus is String ? syncStatus : null;
+  }
+
   Future<List<Map<String, dynamic>>> getAllEntities(String table) async {
     final db = await database;
     final rows = await db.query(

--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -32,6 +32,13 @@ class PetService {
   static const String _actionUpdateVaccination = 'update_vaccination';
   static const String _actionDeleteVaccination = 'delete_vaccination';
   static const String _petIdMappingMetaPrefix = 'pet_id_map.';
+  static const String _photoUrlKey = 'photoUrl';
+  static const String _photoPendingUploadKey = 'photoPendingUpload';
+  static const String _photoStoragePathKey = 'photoStoragePath';
+  static const String _photoLocalFilePathKey = 'photoLocalFilePath';
+  static const String _photoFileNameKey = 'photoFileName';
+  static const String _photoContentTypeKey = 'photoContentType';
+  static const String _photoSizeBytesKey = 'photoSizeBytes';
 
   final ApiClient _apiClient = ApiClient();
   final ResponseCacheService _cache = ResponseCacheService();
@@ -546,9 +553,12 @@ class PetService {
               );
             }
 
+            final updatePayload = await _preparePetUpdatePayloadForApi(
+              _asPetMap(operation.payload ?? const <String, dynamic>{}),
+            );
             final response = await _apiClient.put(
               '$petsPath$petId/',
-              body: jsonEncode(operation.payload ?? const <String, dynamic>{}),
+              body: jsonEncode(updatePayload),
               headers: const {'Content-Type': 'application/json'},
             );
             if (response.body.trim().isNotEmpty) {
@@ -790,6 +800,47 @@ class PetService {
 
     return trimmed;
   }
+
+  Future<Map<String, dynamic>> _preparePetUpdatePayloadForApi(
+    Map<String, dynamic> payload,
+  ) async {
+    final prepared = <String, dynamic>{...payload};
+    if (_hasPendingPetPhotoUpload(prepared)) {
+      final resolvedPhotoUrl = await _attachmentUploadService
+          .resolvePendingUploadUrl(
+            storagePath:
+                (prepared[_photoStoragePathKey] as String?)?.trim() ?? '',
+            localFilePath:
+                (prepared[_photoLocalFilePathKey] as String?)?.trim() ?? '',
+            fileName: (prepared[_photoFileNameKey] as String?)?.trim() ?? '',
+            contentType:
+                (prepared[_photoContentTypeKey] as String?)?.trim() ?? '',
+          );
+      prepared[_photoUrlKey] = resolvedPhotoUrl;
+    }
+
+    for (final key in _localPetPhotoSyncKeys) {
+      prepared.remove(key);
+    }
+    return prepared;
+  }
+
+  bool _hasPendingPetPhotoUpload(Map<String, dynamic> payload) {
+    final isPending = payload[_photoPendingUploadKey] == true;
+    final storagePath =
+        (payload[_photoStoragePathKey] as String?)?.trim() ?? '';
+    final photoUrl = (payload[_photoUrlKey] as String?)?.trim() ?? '';
+    return isPending || (photoUrl.isEmpty && storagePath.isNotEmpty);
+  }
+
+  List<String> get _localPetPhotoSyncKeys => const <String>[
+    _photoPendingUploadKey,
+    _photoStoragePathKey,
+    _photoLocalFilePathKey,
+    _photoFileNameKey,
+    _photoContentTypeKey,
+    _photoSizeBytesKey,
+  ];
 
   bool _isPendingSyncStatus(String? syncStatus) {
     return syncStatus != null && syncStatus.startsWith('pending_');

--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -102,8 +102,20 @@ class PetService {
       return PetModel.fromJson(localPetJson);
     }
 
+    final resolvedPetId = await _resolvePetIdForSync(trimmedPetId);
+    if (resolvedPetId != null && resolvedPetId != trimmedPetId) {
+      final resolvedLocalPetJson = await _localDb.getEntityById(
+        table: LocalDbTables.pets,
+        remoteId: resolvedPetId,
+      );
+      if (resolvedLocalPetJson != null) {
+        return PetModel.fromJson(resolvedLocalPetJson);
+      }
+    }
+
+    final apiPetId = resolvedPetId ?? trimmedPetId;
     try {
-      final response = await _apiClient.get('$petsPath$trimmedPetId/');
+      final response = await _apiClient.get('$petsPath$apiPetId/');
       final json = jsonDecode(response.body);
 
       if (json is! Map<String, dynamic>) {

--- a/lib/core/services/pet_service.dart
+++ b/lib/core/services/pet_service.dart
@@ -182,7 +182,7 @@ class PetService {
       }
 
       final pet = PetModel.fromJson(json);
-      await _persistPetMap(_asPetMap(json));
+      await _persistPetMap(_asPetMap(json), preservePendingLocal: false);
       await _invalidatePetsCache();
       return pet;
     } catch (error) {
@@ -248,12 +248,7 @@ class PetService {
     required String petId,
     required String status,
   }) async {
-    await _apiClient.put(
-      '$petsPath$petId/',
-      body: jsonEncode({'status': status}),
-      headers: const {'Content-Type': 'application/json'},
-    );
-    await _invalidatePetsCache();
+    await updatePet(petId: petId, data: <String, dynamic>{'status': status});
   }
 
   Future<void> addVaccination({
@@ -543,11 +538,28 @@ class PetService {
             }
             break;
           case _actionUpdate:
-            await _apiClient.put(
-              '$petsPath${operation.entityId}/',
+            final petId = await _resolvePetIdForSync(operation.entityId);
+            if (petId == null || petId.isEmpty) {
+              throw const ApiException(
+                type: ApiErrorType.unknown,
+                message: 'Missing pet id in queued pet update operation.',
+              );
+            }
+
+            final response = await _apiClient.put(
+              '$petsPath$petId/',
               body: jsonEncode(operation.payload ?? const <String, dynamic>{}),
               headers: const {'Content-Type': 'application/json'},
             );
+            if (response.body.trim().isNotEmpty) {
+              final decoded = jsonDecode(response.body);
+              if (decoded is Map<String, dynamic>) {
+                await _persistPetMap(
+                  _asPetMap(decoded),
+                  preservePendingLocal: false,
+                );
+              }
+            }
             break;
           case _actionDelete:
             await _apiClient.delete('$petsPath${operation.entityId}/');
@@ -697,10 +709,23 @@ class PetService {
     }
   }
 
-  Future<void> _persistPetMap(Map<String, dynamic> petJson) async {
+  Future<void> _persistPetMap(
+    Map<String, dynamic> petJson, {
+    bool preservePendingLocal = true,
+  }) async {
     final remoteId = _readPetRemoteId(petJson);
     if (remoteId == null) {
       return;
+    }
+
+    if (preservePendingLocal) {
+      final syncStatus = await _localDb.getEntitySyncStatus(
+        table: LocalDbTables.pets,
+        remoteId: remoteId,
+      );
+      if (_isPendingSyncStatus(syncStatus)) {
+        return;
+      }
     }
 
     await _localDb.upsertEntity(
@@ -764,6 +789,10 @@ class PetService {
     }
 
     return trimmed;
+  }
+
+  bool _isPendingSyncStatus(String? syncStatus) {
+    return syncStatus != null && syncStatus.startsWith('pending_');
   }
 
   bool _shouldQueueOffline(Object error) {

--- a/lib/core/services/user_service.dart
+++ b/lib/core/services/user_service.dart
@@ -5,6 +5,7 @@ import 'package:flutter_frontend/core/models/user_profile.dart';
 import 'package:flutter_frontend/core/network/api_client.dart';
 import 'package:flutter_frontend/core/network/api_exception.dart';
 
+import 'attachment_upload_service.dart';
 import 'local_database_service.dart';
 import 'response_cache_service.dart';
 
@@ -20,16 +21,35 @@ class UserService {
   static const Duration _currentUserCacheTtl = Duration(minutes: 5);
   static const String _entityTypeUser = 'user';
   static const String _actionUpdateProfile = 'update_profile';
+  static const String _profilePhotoKey = 'profilePhoto';
+  static const String _profilePhotoPendingUploadKey =
+      'profilePhotoPendingUpload';
+  static const String _profilePhotoStoragePathKey = 'profilePhotoStoragePath';
+  static const String _profilePhotoLocalFilePathKey =
+      'profilePhotoLocalFilePath';
+  static const String _profilePhotoFileNameKey = 'profilePhotoFileName';
+  static const String _profilePhotoContentTypeKey = 'profilePhotoContentType';
+  static const String _profilePhotoSizeBytesKey = 'profilePhotoSizeBytes';
 
   final ApiClient _apiClient = ApiClient();
   final ResponseCacheService _cache = ResponseCacheService();
   final LocalDatabaseService _localDb = LocalDatabaseService();
+  final AttachmentUploadService _attachmentUploadService =
+      AttachmentUploadService();
 
   Future<UserProfile> getCurrentUser({bool forceRefresh = false}) async {
     final cachedEntry = await _cache.get(_currentUserCacheKey);
-    if (!forceRefresh && cachedEntry != null && cachedEntry.isFresh(_currentUserCacheTtl)) {
+    if (!forceRefresh &&
+        cachedEntry != null &&
+        cachedEntry.isFresh(_currentUserCacheTtl)) {
       final cachedProfile = _tryParseCurrentUser(cachedEntry.body);
       if (cachedProfile != null) {
+        final pendingLocalProfile = await _getPendingCurrentUserFromLocalDb(
+          remoteId: cachedProfile.id,
+        );
+        if (pendingLocalProfile != null) {
+          return pendingLocalProfile;
+        }
         unawaited(_persistCurrentUserFromBody(cachedEntry.body));
         return cachedProfile;
       }
@@ -38,6 +58,14 @@ class UserService {
     try {
       final response = await _apiClient.get(currentUserPath);
       final profile = _parseCurrentUser(response.body);
+      final pendingLocalProfile = await _getPendingCurrentUserFromLocalDb(
+        remoteId: profile.id,
+      );
+      if (pendingLocalProfile != null) {
+        await _persistCurrentUserFromBody(response.body);
+        return pendingLocalProfile;
+      }
+
       await _cache.set(_currentUserCacheKey, response.body);
       await _persistCurrentUserFromBody(response.body);
       return profile;
@@ -45,6 +73,12 @@ class UserService {
       if (cachedEntry != null) {
         final fallbackProfile = _tryParseCurrentUser(cachedEntry.body);
         if (fallbackProfile != null) {
+          final pendingLocalProfile = await _getPendingCurrentUserFromLocalDb(
+            remoteId: fallbackProfile.id,
+          );
+          if (pendingLocalProfile != null) {
+            return pendingLocalProfile;
+          }
           unawaited(_persistCurrentUserFromBody(cachedEntry.body));
           return fallbackProfile;
         }
@@ -63,20 +97,20 @@ class UserService {
     String phone = '',
     String address = '',
     String profilePhoto = '',
+    Map<String, dynamic> profilePhotoSyncPayload = const <String, dynamic>{},
   }) async {
     final updatePayload = <String, dynamic>{
       'name': name,
       'phone': phone,
       'address': address,
-      'profilePhoto': profilePhoto,
+      _profilePhotoKey: profilePhoto,
       'initials': _initialsFromName(name),
+      ...profilePhotoSyncPayload,
     };
 
     try {
-      final response = await _apiClient.put(
-        currentUserPath,
-        body: updatePayload,
-      );
+      final apiPayload = await _prepareUserUpdatePayloadForApi(updatePayload);
+      final response = await _apiClient.put(currentUserPath, body: apiPayload);
 
       if (response.body.isEmpty) {
         await _cache.clear(_currentUserCacheKey);
@@ -85,10 +119,14 @@ class UserService {
 
       final profile = _parseCurrentUser(response.body);
       await _cache.set(_currentUserCacheKey, response.body);
-      await _persistCurrentUserFromBody(response.body);
+      await _persistCurrentUserFromBody(
+        response.body,
+        preservePendingLocal: false,
+      );
       return profile;
     } catch (error) {
-      if (!_shouldQueueOffline(error)) {
+      if (!_shouldQueueOffline(error) &&
+          !_shouldQueuePendingProfilePhotoResolution(error, updatePayload)) {
         rethrow;
       }
 
@@ -136,16 +174,27 @@ class UserService {
       try {
         switch (operation.action) {
           case _actionUpdateProfile:
+            final updatePayload =
+                operation.payload ?? const <String, dynamic>{};
+            final apiPayload = await _prepareUserUpdatePayloadForApi(
+              updatePayload,
+            );
             final response = await _apiClient.put(
               currentUserPath,
-              body: operation.payload ?? const <String, dynamic>{},
+              body: apiPayload,
             );
 
             if (response.body.trim().isNotEmpty) {
-              await _persistCurrentUserFromBody(response.body);
+              await _persistCurrentUserFromBody(
+                response.body,
+                preservePendingLocal: false,
+              );
               await _cache.set(_currentUserCacheKey, response.body);
             } else {
-              await _cache.clear(_currentUserCacheKey);
+              await _persistSuccessfulUserUpdatePayload(
+                userId: operation.entityId,
+                payload: apiPayload,
+              );
             }
             break;
           default:
@@ -201,26 +250,66 @@ class UserService {
     return '$first${parts.last[0].toUpperCase()}';
   }
 
-  Future<void> _persistCurrentUserFromBody(String body) async {
+  Future<bool> _persistCurrentUserFromBody(
+    String body, {
+    bool preservePendingLocal = true,
+  }) async {
     try {
       final decoded = jsonDecode(body);
       if (decoded is! Map<String, dynamic>) {
-        return;
+        return false;
       }
 
       final remoteId = decoded['id'];
       if (remoteId is! String || remoteId.trim().isEmpty) {
-        return;
+        return false;
+      }
+
+      final normalizedRemoteId = remoteId.trim();
+      if (preservePendingLocal) {
+        final syncStatus = await _localDb.getEntitySyncStatus(
+          table: LocalDbTables.users,
+          remoteId: normalizedRemoteId,
+        );
+        if (_isPendingSyncStatus(syncStatus)) {
+          return false;
+        }
       }
 
       await _localDb.upsertEntity(
         table: LocalDbTables.users,
-        remoteId: remoteId.trim(),
+        remoteId: normalizedRemoteId,
         payload: decoded,
       );
+      return true;
     } catch (_) {
       // Local persistence is best effort.
+      return false;
     }
+  }
+
+  Future<void> _persistSuccessfulUserUpdatePayload({
+    required String userId,
+    required Map<String, dynamic> payload,
+  }) async {
+    final normalizedUserId = userId.trim();
+    if (normalizedUserId.isEmpty) {
+      return;
+    }
+
+    final localProfileJson = await _getCurrentUserJsonFromLocalDb();
+    final mergedProfile = <String, dynamic>{
+      if (localProfileJson != null) ...localProfileJson,
+      ...payload,
+      'id': normalizedUserId,
+    };
+
+    await _localDb.upsertEntity(
+      table: LocalDbTables.users,
+      remoteId: normalizedUserId,
+      payload: mergedProfile,
+    );
+    await _cache.set(_currentUserCacheKey, jsonEncode(mergedProfile));
   }
 
   Future<UserProfile?> _getCurrentUserFromLocalDb() async {
@@ -249,7 +338,98 @@ class UserService {
     }
   }
 
+  Future<UserProfile?> _getPendingCurrentUserFromLocalDb({
+    String? remoteId,
+  }) async {
+    final userJson = await _getCurrentUserJsonFromLocalDb();
+    if (userJson == null) {
+      return null;
+    }
+
+    final userId = (userJson['id'] as String?)?.trim() ?? '';
+    if (userId.isEmpty) {
+      return null;
+    }
+
+    final normalizedRemoteId = remoteId?.trim() ?? '';
+    if (normalizedRemoteId.isNotEmpty && normalizedRemoteId != userId) {
+      return null;
+    }
+
+    final syncStatus = await _localDb.getEntitySyncStatus(
+      table: LocalDbTables.users,
+      remoteId: userId,
+    );
+    if (!_isPendingSyncStatus(syncStatus)) {
+      return null;
+    }
+
+    try {
+      return UserProfile.fromJson(userJson);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<Map<String, dynamic>> _prepareUserUpdatePayloadForApi(
+    Map<String, dynamic> payload,
+  ) async {
+    final prepared = <String, dynamic>{...payload};
+    if (_hasPendingProfilePhotoUpload(prepared)) {
+      final resolvedPhotoUrl = await _attachmentUploadService
+          .resolvePendingUploadUrl(
+            storagePath:
+                (prepared[_profilePhotoStoragePathKey] as String?)?.trim() ??
+                '',
+            localFilePath:
+                (prepared[_profilePhotoLocalFilePathKey] as String?)?.trim() ??
+                '',
+            fileName:
+                (prepared[_profilePhotoFileNameKey] as String?)?.trim() ?? '',
+            contentType:
+                (prepared[_profilePhotoContentTypeKey] as String?)?.trim() ??
+                '',
+          );
+      prepared[_profilePhotoKey] = resolvedPhotoUrl;
+    }
+
+    for (final key in _localProfilePhotoSyncKeys) {
+      prepared.remove(key);
+    }
+    return prepared;
+  }
+
+  bool _hasPendingProfilePhotoUpload(Map<String, dynamic> payload) {
+    final isPending = payload[_profilePhotoPendingUploadKey] == true;
+    final storagePath =
+        (payload[_profilePhotoStoragePathKey] as String?)?.trim() ?? '';
+    final profilePhoto = (payload[_profilePhotoKey] as String?)?.trim() ?? '';
+    return isPending || (profilePhoto.isEmpty && storagePath.isNotEmpty);
+  }
+
+  List<String> get _localProfilePhotoSyncKeys => const <String>[
+    _profilePhotoPendingUploadKey,
+    _profilePhotoStoragePathKey,
+    _profilePhotoLocalFilePathKey,
+    _profilePhotoFileNameKey,
+    _profilePhotoContentTypeKey,
+    _profilePhotoSizeBytesKey,
+  ];
+
+  bool _isPendingSyncStatus(String? syncStatus) {
+    return syncStatus != null && syncStatus.startsWith('pending_');
+  }
+
   bool _shouldQueueOffline(Object error) {
     return error is ApiException && error.type == ApiErrorType.network;
+  }
+
+  bool _shouldQueuePendingProfilePhotoResolution(
+    Object error,
+    Map<String, dynamic> payload,
+  ) {
+    final message = error.toString();
+    return message.contains('Attachment upload still pending') &&
+        _hasPendingProfilePhotoUpload(payload);
   }
 }

--- a/lib/presentation/pages/pets/add_pet/add_pet_screen.dart
+++ b/lib/presentation/pages/pets/add_pet/add_pet_screen.dart
@@ -300,7 +300,19 @@ class _AddPetScreenState extends State<AddPetScreen> {
 
         savedPet = await petService.updatePet(
           petId: savedPet.id,
-          data: {...payload, 'photoUrl': uploadedPhoto.downloadUrl},
+          data: {
+            ...payload,
+            'photoUrl': uploadedPhoto.downloadUrl,
+            if (uploadedPhoto.isPendingUpload) ...{
+              'photoPendingUpload': true,
+              'photoStoragePath': uploadedPhoto.storagePath,
+              if (uploadedPhoto.localFilePath?.trim().isNotEmpty == true)
+                'photoLocalFilePath': uploadedPhoto.localFilePath!.trim(),
+              'photoFileName': uploadedPhoto.fileName,
+              'photoContentType': uploadedPhoto.contentType,
+              'photoSizeBytes': uploadedPhoto.sizeBytes,
+            },
+          },
         );
 
         if (uploadedPhoto.localFilePath != null &&

--- a/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
+++ b/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
@@ -14,6 +14,7 @@ import '../../../../core/models/pet_model.dart';
 import '../../../../core/models/smart_alert_model.dart';
 import '../../../../core/network/api_exception.dart';
 import '../../../../core/services/app_image_cache_manager.dart';
+import '../../../../core/services/connectivity_sync_service.dart';
 import '../../../../core/services/event_service.dart';
 import '../../../../core/services/pet_service.dart';
 import '../../../../core/services/profile_photo_service.dart';
@@ -48,6 +49,8 @@ class PetDetailScreen extends StatefulWidget {
 class _PetDetailScreenState extends State<PetDetailScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
+  final ConnectivitySyncService _connectivitySyncService =
+      ConnectivitySyncService();
   final PetService _petService = PetService();
   final EventService _eventService = EventService();
   final SmartFeatureService _smartFeatureService = SmartFeatureService();
@@ -240,6 +243,8 @@ class _PetDetailScreenState extends State<PetDetailScreen>
     }
 
     try {
+      final wasOffline = !await _connectivitySyncService.hasInternetAccess();
+
       if (isLost) {
         await _petService.markPetAsFound(_pet.id);
       } else {
@@ -253,9 +258,11 @@ class _PetDetailScreenState extends State<PetDetailScreen>
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            isLost
-                ? '${_pet.name} ${AppStrings.petMarkedAsFoundMessage}'
-                : '${_pet.name} ${AppStrings.petMarkedAsLostMessage}',
+            _lostModeMessage(
+              petName: _pet.name,
+              wasLost: isLost,
+              wasOffline: wasOffline,
+            ),
           ),
         ),
       );
@@ -277,6 +284,22 @@ class _PetDetailScreenState extends State<PetDetailScreen>
         context,
       ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
     }
+  }
+
+  String _lostModeMessage({
+    required String petName,
+    required bool wasLost,
+    required bool wasOffline,
+  }) {
+    if (wasOffline) {
+      return wasLost
+          ? AppStrings.petMarkedAsFoundOfflineMessage
+          : AppStrings.petMarkedAsLostOfflineMessage;
+    }
+
+    return wasLost
+        ? '$petName ${AppStrings.petMarkedAsFoundMessage}'
+        : '$petName ${AppStrings.petMarkedAsLostMessage}';
   }
 
   Future<void> _toggleNfc() async {

--- a/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
+++ b/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
@@ -128,21 +128,26 @@ class _PetDetailScreenState extends State<PetDetailScreen>
         detail = localMatch.first;
       }
 
-      final localPath = await _photoService.getPetPhotoPath(widget.pet.id);
+      final effectivePetId = detail.id.trim().isNotEmpty
+          ? detail.id
+          : widget.pet.id;
+      final localPath =
+          await _photoService.getPetPhotoPath(effectivePetId) ??
+          await _photoService.getPetPhotoPath(widget.pet.id);
       final uiPet = detail.toUiModel().copyWith(localPhotoPath: localPath);
       List<EventModel> petEvents = const [];
       List<SmartSuggestionModel> smartSuggestions = const [];
       String? eventsErrorMessage;
 
       try {
-        petEvents = await _eventService.getEventsByPet(widget.pet.id);
+        petEvents = await _eventService.getEventsByPet(effectivePetId);
       } on ApiException catch (error) {
-        final isLocalPet = widget.pet.id.trim().startsWith('local_');
+        final isLocalPet = effectivePetId.trim().startsWith('local_');
         if (!isLocalPet) {
           eventsErrorMessage = error.message;
         }
       } catch (_) {
-        final isLocalPet = widget.pet.id.trim().startsWith('local_');
+        final isLocalPet = effectivePetId.trim().startsWith('local_');
         if (!isLocalPet) {
           eventsErrorMessage = AppStrings.errorGeneric;
         }
@@ -150,7 +155,7 @@ class _PetDetailScreenState extends State<PetDetailScreen>
 
       try {
         final smartResponse = await _smartFeatureService.getPetSmartSuggestions(
-          widget.pet.id,
+          effectivePetId,
         );
         smartSuggestions = smartResponse.suggestions;
       } catch (_) {

--- a/lib/presentation/pages/pets/pets_page.dart
+++ b/lib/presentation/pages/pets/pets_page.dart
@@ -4,6 +4,7 @@ import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_dimensions.dart';
 import '../../../core/constants/app_strings.dart';
 import '../../../core/network/api_exception.dart';
+import '../../../core/services/connectivity_sync_service.dart';
 import '../../../core/services/pet_service.dart';
 import '../../../core/services/profile_photo_service.dart';
 import '../../../core/services/telemetry_service.dart';
@@ -25,6 +26,8 @@ class PetsPage extends StatefulWidget {
 }
 
 class _PetsPageState extends State<PetsPage> {
+  final ConnectivitySyncService _connectivitySyncService =
+      ConnectivitySyncService();
   final PetService _petService = PetService();
   final ProfilePhotoService _photoService = ProfilePhotoService();
   final TelemetryService _telemetryService = TelemetryService();
@@ -142,17 +145,11 @@ class _PetsPageState extends State<PetsPage> {
     Navigator.of(context).pushNamed(Routes.addEvent);
   }
 
-  Future<void> _openPetDetail(
-    PetUiModel pet, {
-    int initialTabIndex = 0,
-  }) async {
+  Future<void> _openPetDetail(PetUiModel pet, {int initialTabIndex = 0}) async {
     final changed = await Navigator.pushNamed(
       context,
       Routes.petDetail,
-      arguments: PetDetailArgs(
-        pet: pet,
-        initialTabIndex: initialTabIndex,
-      ),
+      arguments: PetDetailArgs(pet: pet, initialTabIndex: initialTabIndex),
     );
 
     if (!mounted || changed != true) {
@@ -168,9 +165,7 @@ class _PetsPageState extends State<PetsPage> {
       builder: (dialogContext) {
         return AlertDialog(
           title: const Text(AppStrings.petLostConfirmTitle),
-          content: Text(
-            '${AppStrings.petLostConfirmMessage} (${pet.name})',
-          ),
+          content: Text('${AppStrings.petLostConfirmMessage} (${pet.name})'),
           actions: [
             TextButton(
               onPressed: () => Navigator.of(dialogContext).pop(false),
@@ -199,6 +194,8 @@ class _PetsPageState extends State<PetsPage> {
     }
 
     try {
+      final wasOffline = !await _connectivitySyncService.hasInternetAccess();
+
       if (isLost) {
         await _petService.markPetAsFound(pet.id);
       } else {
@@ -212,9 +209,11 @@ class _PetsPageState extends State<PetsPage> {
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(
           content: Text(
-            isLost
-                ? '${pet.name} ${AppStrings.petMarkedAsFoundMessage}'
-                : '${pet.name} ${AppStrings.petMarkedAsLostMessage}',
+            _lostModeMessage(
+              petName: pet.name,
+              wasLost: isLost,
+              wasOffline: wasOffline,
+            ),
           ),
         ),
       );
@@ -223,17 +222,33 @@ class _PetsPageState extends State<PetsPage> {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(error.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
     } catch (_) {
       if (!mounted) {
         return;
       }
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text(AppStrings.petsLoadError)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
     }
+  }
+
+  String _lostModeMessage({
+    required String petName,
+    required bool wasLost,
+    required bool wasOffline,
+  }) {
+    if (wasOffline) {
+      return wasLost
+          ? AppStrings.petMarkedAsFoundOfflineMessage
+          : AppStrings.petMarkedAsLostOfflineMessage;
+    }
+
+    return wasLost
+        ? '$petName ${AppStrings.petMarkedAsFoundMessage}'
+        : '$petName ${AppStrings.petMarkedAsLostMessage}';
   }
 
   Future<void> _handleNfcTap(PetUiModel pet) async {
@@ -248,9 +263,9 @@ class _PetsPageState extends State<PetsPage> {
           return;
         }
 
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('${pet.name} NFC deactivated')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('${pet.name} NFC deactivated')));
         await _loadPets();
         return;
       }
@@ -273,17 +288,17 @@ class _PetsPageState extends State<PetsPage> {
         return;
       }
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(error.message)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
     } catch (_) {
       if (!mounted) {
         return;
       }
 
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text(AppStrings.petsLoadError)),
-      );
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
     }
   }
 

--- a/lib/presentation/pages/profile/edit_profile_page.dart
+++ b/lib/presentation/pages/profile/edit_profile_page.dart
@@ -39,6 +39,8 @@ class _EditProfilePageState extends State<EditProfilePage> {
   bool _isSaving = false;
   bool _isUploadingPhoto = false;
   String _profilePhotoValue = '';
+  Map<String, dynamic> _pendingProfilePhotoSyncPayload =
+      const <String, dynamic>{};
   Uint8List? _selectedPhotoBytes;
   String? _errorMessage;
 
@@ -82,6 +84,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
         phone: _phoneController.text.trim(),
         address: _addressController.text.trim(),
         profilePhoto: _profilePhotoValue.trim(),
+        profilePhotoSyncPayload: _pendingProfilePhotoSyncPayload,
       );
 
       if (!mounted) {
@@ -177,8 +180,20 @@ class _EditProfilePageState extends State<EditProfilePage> {
         await _photoService.clearLocalPhoto();
       }
 
+      final pendingProfilePhotoSyncPayload = uploadedPhoto.isPendingUpload
+          ? <String, dynamic>{
+              'profilePhotoPendingUpload': true,
+              'profilePhotoStoragePath': uploadedPhoto.storagePath,
+              'profilePhotoLocalFilePath': uploadedPhoto.localFilePath,
+              'profilePhotoFileName': uploadedPhoto.fileName,
+              'profilePhotoContentType': uploadedPhoto.contentType,
+              'profilePhotoSizeBytes': uploadedPhoto.sizeBytes,
+            }
+          : const <String, dynamic>{};
+
       setState(() {
         _profilePhotoValue = uploadedPhoto.downloadUrl;
+        _pendingProfilePhotoSyncPayload = pendingProfilePhotoSyncPayload;
       });
     } catch (error) {
       if (!mounted) {
@@ -202,6 +217,7 @@ class _EditProfilePageState extends State<EditProfilePage> {
     await _photoService.clearLocalPhoto();
     setState(() {
       _profilePhotoValue = '';
+      _pendingProfilePhotoSyncPayload = const <String, dynamic>{};
       _selectedPhotoBytes = null;
     });
   }


### PR DESCRIPTION
**Changelog PR**

- Added offline sync support for event attachments, resolving pending uploads before create/update retry.
- Fixed offline pet photo sync so pending local photos resolve to Firebase URLs before hitting the API.
- Fixed `local_pet_*` to remote pet id resolution to avoid transient unauthorized errors after reconnect.
- Added offline profile photo sync using the same pending-upload metadata flow.
- Protected pending offline profile edits from being overwritten by stale cached/server data.
- Verified with `flutter analyze` and `git diff --check`.