### PR TITLE
Add lost pets marketplace flow

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.NFC"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES"/>
     <uses-feature android:name="android.hardware.nfc" android:required="false"/>

--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -6,13 +6,18 @@ import 'package:flutter_frontend/presentation/pages/add_vaccine/add_vaccine_page
 import 'package:flutter_frontend/presentation/pages/auth/auth_gate.dart';
 import 'package:flutter_frontend/presentation/pages/calendar/calendar_page.dart';
 import 'package:flutter_frontend/presentation/pages/nfc/nfc_page.dart';
+import 'package:flutter_frontend/core/models/lost_pet_model.dart';
 import 'package:flutter_frontend/core/models/user_profile.dart';
+import 'package:flutter_frontend/presentation/pages/lost_pets/lost_pet_detail_page.dart';
+import 'package:flutter_frontend/presentation/pages/lost_pets/lost_pets_page.dart';
+import 'package:flutter_frontend/presentation/pages/lost_pets/lost_pet_sighting_detail_page.dart';
 import 'package:flutter_frontend/presentation/pages/records/detail/detail_page.dart';
 import 'package:flutter_frontend/presentation/pages/smart_alerts/smart_alerts_page.dart';
 import '../presentation/pages/auth/auth_page.dart';
 import '../presentation/pages/home/home_page.dart';
 import '../presentation/pages/pets/models/pet_ui_model.dart';
 import '../presentation/pages/pets/add_pet/add_pet_screen.dart';
+import '../presentation/pages/pets/lost_mode/lost_mode_form_page.dart';
 import '../presentation/pages/pets/pet_detail/pet_detail_args.dart';
 import '../presentation/pages/pets/pet_detail/pet_detail_screen.dart';
 import '../presentation/pages/pets/pets_page.dart';
@@ -33,6 +38,10 @@ class Routes {
   static const String auth = '/auth';
   static const String welcomePage = '/welcome';
   static const String pets = '/pets';
+  static const String lostPets = '/lost-pets';
+  static const String lostPetDetail = '/lost-pets/detail';
+  static const String lostPetSightingDetail = '/lost-pets/sighting-detail';
+  static const String lostMode = '/pets/lost-mode';
   static const String addPet = '/pets/add';
   static const String petDetail = '/pets/detail';
   static const String addVaccine = '/vaccines/add';
@@ -67,6 +76,36 @@ class Routes {
         return _buildRoute(const HomePage(), settings);
 
       case pets:
+        return _buildRoute(const PetsPage(), settings);
+
+      case lostPets:
+        return _buildRoute(const LostPetsPage(), settings);
+
+      case lostPetDetail:
+        final report = settings.arguments;
+        if (report is LostPetReportModel) {
+          return _buildRoute(
+            LostPetDetailPage(initialReport: report),
+            settings,
+          );
+        }
+        return _buildRoute(const LostPetsPage(), settings);
+
+      case lostPetSightingDetail:
+        final args = settings.arguments;
+        if (args is LostPetSightingDetailArgs) {
+          return _buildRoute(
+            LostPetSightingDetailPage(notification: args.notification),
+            settings,
+          );
+        }
+        return _buildRoute(const LostPetsPage(), settings);
+
+      case lostMode:
+        final pet = settings.arguments;
+        if (pet is PetUiModel) {
+          return _buildRoute(LostModeFormPage(pet: pet), settings);
+        }
         return _buildRoute(const PetsPage(), settings);
 
       case addPet:
@@ -189,7 +228,7 @@ class Routes {
     return switch (index) {
       0 => home,
       1 => pets,
-      2 => records,
+      2 => lostPets,
       3 => calendar,
 
       4 => profile,

--- a/lib/core/constants/app_strings.dart
+++ b/lib/core/constants/app_strings.dart
@@ -31,6 +31,41 @@ abstract class AppStrings {
   static const String homeNeedsAttention = 'Needs Attention';
   static const String homeLost = 'Lost';
 
+  // --- Lost pets ---
+  static const String lostPetsTitle = 'Lost Pets in Bogotá';
+  static const String lostPetsSubtitle = 'Pets that need help right now';
+  static const String lostPetsHelpTitle =
+      'Help reunite pets with their families';
+  static const String lostPetsHelpBody =
+      "If you've seen any of these pets, tap to see contact details and reach out to the owner.";
+  static const String lostPetsEmpty = 'No lost pets reported right now.';
+  static const String lostPetsLoadError =
+      'Could not load lost pets. Please try again.';
+  static const String lostPetsRetry = 'Retry';
+  static const String lostPetDetailTitle = 'Lost Pet Details';
+  static const String lostPetLastSeen = 'Last seen';
+  static const String lostPetMedicalInfo = 'Important medical info';
+  static const String lostPetOwnerContact = 'Owner contact';
+  static const String lostPetEmergencyContacts = 'Emergency contacts';
+  static const String lostPetCall = 'Call';
+  static const String lostPetWhatsApp = 'WhatsApp';
+  static const String lostPetLocationUnavailable =
+      'We could not access your location.';
+  static const String lostModeTitle = 'Lost Mode';
+  static const String lostModeNoteLabel = 'Public note';
+  static const String lostModeNoteHint =
+      'Add allergies, behavior, visible details, or instructions.';
+  static const String lostModeLocationLabel = 'Last seen location';
+  static const String lostModeLocationNameHint = 'Parque El Virrey, Bogotá';
+  static const String lostModeUseCurrentLocation = 'Use current location';
+  static const String lostModeContactName = 'Contact name';
+  static const String lostModeContactPhone = 'Phone';
+  static const String lostModeActivate = 'Activate Lost Mode';
+  static const String lostModeSave = 'Save Lost Mode';
+  static const String lostModeMarkFound = 'Mark as Found';
+  static const String lostModeSaved = 'Lost Mode updated.';
+  static const String lostModeFound = 'Pet marked as found.';
+
   // --- NFC page ---
   static const String nfcTitle = 'NFC Tag';
   static const String nfcReadTag = 'Read Tag';

--- a/lib/core/models/lost_pet_model.dart
+++ b/lib/core/models/lost_pet_model.dart
@@ -1,0 +1,416 @@
+class LostPetContactModel {
+  const LostPetContactModel({
+    required this.name,
+    required this.phone,
+    required this.whatsapp,
+    required this.relationship,
+    required this.isPrimary,
+    required this.allowCall,
+    required this.allowWhatsApp,
+  });
+
+  final String name;
+  final String phone;
+  final String whatsapp;
+  final String relationship;
+  final bool isPrimary;
+  final bool allowCall;
+  final bool allowWhatsApp;
+
+  factory LostPetContactModel.fromJson(Map<String, dynamic> json) {
+    final phone = _readStringByKeys(json, const ['phone']);
+    final whatsapp = _readStringByKeys(json, const ['whatsapp']);
+
+    return LostPetContactModel(
+      name: _readStringByKeys(json, const ['name']),
+      phone: phone,
+      whatsapp: whatsapp,
+      relationship: _readStringByKeys(json, const [
+        'relationship',
+      ], fallback: 'Emergency contact'),
+      isPrimary: _readBoolByKeys(json, const [
+        'isPrimary',
+        'is_primary',
+        'preferred',
+      ]),
+      allowCall: _readBoolByKeys(json, const [
+        'allowCall',
+        'allow_call',
+        'exposePhone',
+        'expose_phone',
+      ], fallback: phone.trim().isNotEmpty),
+      allowWhatsApp: _readBoolByKeys(json, const [
+        'allowWhatsApp',
+        'allow_whatsapp',
+        'exposeWhatsapp',
+        'expose_whatsapp',
+      ], fallback: whatsapp.trim().isNotEmpty),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'phone': phone,
+      'whatsapp': whatsapp,
+      'relationship': relationship,
+      'isPrimary': isPrimary,
+      'allowCall': allowCall,
+      'allowWhatsApp': allowWhatsApp,
+    };
+  }
+}
+
+class LostPetLocationModel {
+  const LostPetLocationModel({
+    this.name = '',
+    this.latitude,
+    this.longitude,
+    this.source = '',
+    this.accuracyMeters,
+    this.seenAt,
+  });
+
+  final String name;
+  final double? latitude;
+  final double? longitude;
+  final String source;
+  final double? accuracyMeters;
+  final DateTime? seenAt;
+
+  bool get hasCoordinates => latitude != null && longitude != null;
+
+  factory LostPetLocationModel.fromJson(Map<String, dynamic> json) {
+    return LostPetLocationModel(
+      name: _readStringByKeys(json, const [
+        'name',
+        'location',
+        'locationName',
+        'location_name',
+        'lastSeenLocation',
+        'lastSeenLocationName',
+      ]),
+      latitude: _readDoubleByKeys(json, const [
+        'latitude',
+        'lat',
+        'lastSeenLat',
+        'last_seen_lat',
+        'lastSeenLatitude',
+      ]),
+      longitude: _readDoubleByKeys(json, const [
+        'longitude',
+        'lng',
+        'lastSeenLng',
+        'last_seen_lng',
+        'lastSeenLongitude',
+      ]),
+      source: _readStringByKeys(json, const [
+        'source',
+        'lastSeenSource',
+        'last_seen_source',
+      ]),
+      accuracyMeters: _readDoubleByKeys(json, const [
+        'accuracyMeters',
+        'accuracy_meters',
+      ]),
+      seenAt: _parseDate(
+        _readValueByKeys(json, const ['seenAt', 'seen_at', 'lastSeenAt']),
+      ),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'name': name,
+      'latitude': latitude,
+      'longitude': longitude,
+      'source': source,
+      'accuracyMeters': accuracyMeters,
+      'seenAt': seenAt?.toIso8601String(),
+    };
+  }
+}
+
+class LostPetReportModel {
+  const LostPetReportModel({
+    required this.id,
+    required this.petId,
+    required this.ownerId,
+    required this.city,
+    required this.status,
+    required this.petName,
+    required this.species,
+    required this.breed,
+    required this.gender,
+    required this.color,
+    this.weight,
+    this.ageLabel = '',
+    this.photoUrl,
+    this.knownAllergies = '',
+    this.defaultVet = '',
+    this.defaultClinic = '',
+    this.microchipId = '',
+    this.lostNote = '',
+    this.exposeMedicalInfo = false,
+    this.nfcNotificationsEnabled = true,
+    required this.lastSeen,
+    required this.contacts,
+    this.createdAt,
+    this.updatedAt,
+    this.resolvedAt,
+  });
+
+  final String id;
+  final String petId;
+  final String ownerId;
+  final String city;
+  final String status;
+  final String petName;
+  final String species;
+  final String breed;
+  final String gender;
+  final String color;
+  final double? weight;
+  final String ageLabel;
+  final String? photoUrl;
+  final String knownAllergies;
+  final String defaultVet;
+  final String defaultClinic;
+  final String microchipId;
+  final String lostNote;
+  final bool exposeMedicalInfo;
+  final bool nfcNotificationsEnabled;
+  final LostPetLocationModel lastSeen;
+  final List<LostPetContactModel> contacts;
+  final DateTime? createdAt;
+  final DateTime? updatedAt;
+  final DateTime? resolvedAt;
+
+  bool get isActive => status == 'active';
+
+  LostPetContactModel? get primaryContact {
+    for (final contact in contacts) {
+      if (contact.isPrimary) {
+        return contact;
+      }
+    }
+    return contacts.isEmpty ? null : contacts.first;
+  }
+
+  factory LostPetReportModel.fromJson(Map<String, dynamic> json) {
+    final contactsJson = _readListByKeys(json, const [
+      'contacts',
+      'emergencyContacts',
+      'emergency_contacts',
+    ]);
+    final locationJson = _readLocationJson(json);
+    final petJson = _asStringDynamicMap(_readValueByKeys(json, const ['pet']));
+
+    return LostPetReportModel(
+      id: _readStringByKeys(json, const ['id', '_id']),
+      petId: _readStringByKeys(json, const ['petId', 'pet_id']).isNotEmpty
+          ? _readStringByKeys(json, const ['petId', 'pet_id'])
+          : _readStringByKeys(petJson, const ['id', '_id']),
+      ownerId: _readStringByKeys(json, const ['ownerId', 'owner_id']),
+      city: _readStringByKeys(json, const ['city'], fallback: 'Bogotá'),
+      status: _readStringByKeys(json, const ['status'], fallback: 'active'),
+      petName:
+          _readStringByKeys(json, const [
+            'petName',
+            'pet_name',
+            'name',
+          ]).isNotEmpty
+          ? _readStringByKeys(json, const ['petName', 'pet_name', 'name'])
+          : _readStringByKeys(petJson, const ['name']),
+      species: _readStringByKeys(json, const ['species']).isNotEmpty
+          ? _readStringByKeys(json, const ['species'])
+          : _readStringByKeys(petJson, const ['species']),
+      breed: _readStringByKeys(json, const ['breed']).isNotEmpty
+          ? _readStringByKeys(json, const ['breed'])
+          : _readStringByKeys(petJson, const ['breed']),
+      gender: _readStringByKeys(json, const ['gender']).isNotEmpty
+          ? _readStringByKeys(json, const ['gender'])
+          : _readStringByKeys(petJson, const ['gender']),
+      color: _readStringByKeys(json, const ['color']).isNotEmpty
+          ? _readStringByKeys(json, const ['color'])
+          : _readStringByKeys(petJson, const ['color']),
+      weight:
+          _readDoubleByKeys(json, const ['weight']) ??
+          _readDoubleByKeys(petJson, const ['weight']),
+      ageLabel: _readStringByKeys(json, const ['ageLabel', 'age_label']),
+      photoUrl: _readNullableString(
+        _readValueByKeys(json, const ['photoUrl', 'photo_url']) ??
+            _readValueByKeys(petJson, const ['photoUrl', 'photo_url']),
+      ),
+      knownAllergies: _readStringByKeys(json, const [
+        'knownAllergies',
+        'known_allergies',
+      ]),
+      defaultVet: _readStringByKeys(json, const ['defaultVet', 'default_vet']),
+      defaultClinic: _readStringByKeys(json, const [
+        'defaultClinic',
+        'default_clinic',
+      ]),
+      microchipId: _readStringByKeys(json, const [
+        'microchipId',
+        'microchip_id',
+      ]),
+      lostNote: _readStringByKeys(json, const [
+        'lostNote',
+        'lost_note',
+        'note',
+      ]),
+      exposeMedicalInfo: _readBoolByKeys(json, const [
+        'exposeMedicalInfo',
+        'expose_medical_info',
+      ]),
+      nfcNotificationsEnabled: _readBoolByKeys(json, const [
+        'nfcNotificationsEnabled',
+        'nfc_notifications_enabled',
+      ], fallback: true),
+      lastSeen: LostPetLocationModel.fromJson(locationJson),
+      contacts: contactsJson
+          .map(_asStringDynamicMap)
+          .map(LostPetContactModel.fromJson)
+          .toList(growable: false),
+      createdAt: _parseDate(_readValueByKeys(json, const ['createdAt'])),
+      updatedAt: _parseDate(_readValueByKeys(json, const ['updatedAt'])),
+      resolvedAt: _parseDate(_readValueByKeys(json, const ['resolvedAt'])),
+    );
+  }
+}
+
+Map<String, dynamic> _readLocationJson(Map<String, dynamic> json) {
+  final nested = _readValueByKeys(json, const [
+    'lastSeen',
+    'last_seen',
+    'location',
+  ]);
+  if (nested is Map<String, dynamic>) {
+    return nested;
+  }
+  if (nested is Map) {
+    return nested.map((key, value) => MapEntry(key.toString(), value));
+  }
+  return json;
+}
+
+Map<String, dynamic> _asStringDynamicMap(dynamic value) {
+  if (value is Map<String, dynamic>) {
+    return value;
+  }
+
+  if (value is Map) {
+    return value.map((key, item) => MapEntry(key.toString(), item));
+  }
+
+  return const <String, dynamic>{};
+}
+
+DateTime? _parseDate(dynamic value) {
+  if (value is! String || value.trim().isEmpty) {
+    return null;
+  }
+  return DateTime.tryParse(value);
+}
+
+double? _readDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value is String) {
+    return double.tryParse(value);
+  }
+  return null;
+}
+
+double? _readDoubleByKeys(Map<String, dynamic> json, List<String> keys) {
+  return _readDouble(_readValueByKeys(json, keys));
+}
+
+String _readString(dynamic value, {String fallback = ''}) {
+  if (value is String) {
+    return value;
+  }
+  if (value == null) {
+    return fallback;
+  }
+  return value.toString();
+}
+
+String? _readNullableString(dynamic value) {
+  final text = _readString(value).trim();
+  return text.isEmpty ? null : text;
+}
+
+bool _readBoolByKeys(
+  Map<String, dynamic> json,
+  List<String> keys, {
+  bool fallback = false,
+}) {
+  final value = _readValueByKeys(json, keys);
+  if (value is bool) {
+    return value;
+  }
+  if (value is num) {
+    return value != 0;
+  }
+  if (value is String) {
+    final normalized = value.trim().toLowerCase();
+    if (normalized == 'true' || normalized == '1' || normalized == 'yes') {
+      return true;
+    }
+    if (normalized == 'false' || normalized == '0' || normalized == 'no') {
+      return false;
+    }
+  }
+  return fallback;
+}
+
+List<dynamic> _readListByKeys(Map<String, dynamic> json, List<String> keys) {
+  final value = _readValueByKeys(json, keys);
+  if (value is List) {
+    return value;
+  }
+  return const [];
+}
+
+String _readStringByKeys(
+  Map<String, dynamic> json,
+  List<String> keys, {
+  String fallback = '',
+}) {
+  final value = _readValueByKeys(json, keys);
+  final idFromMap = _readObjectIdFromMap(value);
+  if (idFromMap != null) {
+    return idFromMap;
+  }
+  return _readString(value, fallback: fallback);
+}
+
+dynamic _readValueByKeys(Map<String, dynamic> json, List<String> keys) {
+  for (final key in keys) {
+    if (json.containsKey(key)) {
+      return json[key];
+    }
+  }
+  return null;
+}
+
+String? _readObjectIdFromMap(dynamic value) {
+  if (value is! Map) {
+    return null;
+  }
+
+  final oid = value['\$oid'];
+  if (oid is String && oid.trim().isNotEmpty) {
+    return oid;
+  }
+
+  final nestedId = value['id'] ?? value['_id'];
+  if (nestedId is String && nestedId.trim().isNotEmpty) {
+    return nestedId;
+  }
+
+  return null;
+}

--- a/lib/core/models/notification_model.dart
+++ b/lib/core/models/notification_model.dart
@@ -1,0 +1,100 @@
+class NotificationModel {
+  const NotificationModel({
+    required this.id,
+    required this.type,
+    required this.header,
+    required this.text,
+    this.actionLabel = '',
+    this.actionPhone = '',
+    this.actionWhatsapp = '',
+    this.actionReportId = '',
+    this.actionPetId = '',
+    this.actionPetName = '',
+    this.actionPetPhotoUrl = '',
+    this.actionReporterName = '',
+    this.actionLocation = '',
+    this.actionLatitude,
+    this.actionLongitude,
+    this.dateSent,
+    this.isRead = false,
+  });
+
+  final String id;
+  final String type;
+  final String header;
+  final String text;
+  final String actionLabel;
+  final String actionPhone;
+  final String actionWhatsapp;
+  final String actionReportId;
+  final String actionPetId;
+  final String actionPetName;
+  final String actionPetPhotoUrl;
+  final String actionReporterName;
+  final String actionLocation;
+  final double? actionLatitude;
+  final double? actionLongitude;
+  final DateTime? dateSent;
+  final bool isRead;
+
+  bool get hasCallAction => actionPhone.trim().isNotEmpty;
+  bool get hasWhatsAppAction => actionWhatsapp.trim().isNotEmpty;
+  bool get hasLostPetReport => actionReportId.trim().isNotEmpty;
+  bool get hasActionLocation =>
+      actionLatitude != null && actionLongitude != null;
+
+  factory NotificationModel.fromJson(Map<String, dynamic> json) {
+    return NotificationModel(
+      id: _readString(json['id'] ?? json['_id']),
+      type: _readString(json['type']),
+      header: _readString(json['header']),
+      text: _readString(json['text']),
+      actionLabel: _readString(json['actionLabel'] ?? json['action_label']),
+      actionPhone: _readString(json['actionPhone'] ?? json['action_phone']),
+      actionWhatsapp: _readString(
+        json['actionWhatsapp'] ?? json['action_whatsapp'],
+      ),
+      actionReportId: _readString(
+        json['actionReportId'] ?? json['action_report_id'],
+      ),
+      actionPetId: _readString(json['actionPetId'] ?? json['action_pet_id']),
+      actionPetName: _readString(
+        json['actionPetName'] ?? json['action_pet_name'],
+      ),
+      actionPetPhotoUrl: _readString(
+        json['actionPetPhotoUrl'] ?? json['action_pet_photo_url'],
+      ),
+      actionReporterName: _readString(
+        json['actionReporterName'] ?? json['action_reporter_name'],
+      ),
+      actionLocation: _readString(
+        json['actionLocation'] ?? json['action_location'],
+      ),
+      actionLatitude: _readDouble(
+        json['actionLatitude'] ?? json['action_latitude'],
+      ),
+      actionLongitude: _readDouble(
+        json['actionLongitude'] ?? json['action_longitude'],
+      ),
+      dateSent: DateTime.tryParse(_readString(json['dateSent'])),
+      isRead: json['isRead'] == true || json['is_read'] == true,
+    );
+  }
+}
+
+double? _readDouble(dynamic value) {
+  if (value is num) {
+    return value.toDouble();
+  }
+  if (value is String) {
+    return double.tryParse(value);
+  }
+  return null;
+}
+
+String _readString(dynamic value) {
+  if (value == null) {
+    return '';
+  }
+  return value.toString();
+}

--- a/lib/core/services/app_preferences_service.dart
+++ b/lib/core/services/app_preferences_service.dart
@@ -11,6 +11,8 @@ class AppPreferencesService {
   static const String _themePreferenceKey = 'app_preferences.theme_preference';
   static const String _notificationsEnabledKey =
       'app_preferences.notifications_enabled';
+  static const String _dismissedLostPetNotificationsKey =
+      'app_preferences.dismissed_lost_pet_notifications';
   static const String _hasSeenWelcomeKey = 'app_preferences.has_seen_welcome';
 
   Future<AppThemePreference?> getThemePreference() async {
@@ -39,6 +41,22 @@ class AppPreferencesService {
   Future<void> setNotificationsEnabled(bool value) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool(_notificationsEnabledKey, value);
+  }
+
+  Future<Set<String>> getDismissedLostPetNotificationIds() async {
+    final prefs = await SharedPreferences.getInstance();
+    return (prefs.getStringList(_dismissedLostPetNotificationsKey) ??
+            const <String>[])
+        .where((id) => id.trim().isNotEmpty)
+        .toSet();
+  }
+
+  Future<void> setDismissedLostPetNotificationIds(Set<String> ids) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setStringList(
+      _dismissedLostPetNotificationsKey,
+      ids.toList(growable: false),
+    );
   }
 
   Future<bool> getHasSeenWelcome() async {

--- a/lib/core/services/local_database_service.dart
+++ b/lib/core/services/local_database_service.dart
@@ -9,6 +9,7 @@ class LocalDbTables {
   static const String events = 'events_local';
   static const String vaccines = 'vaccines_local';
   static const String petVaccinations = 'pet_vaccinations_local';
+  static const String lostPets = 'lost_pets_local';
   static const String syncQueue = 'sync_queue';
   static const String appMeta = 'app_meta';
 }
@@ -75,7 +76,7 @@ class LocalDatabaseService {
   factory LocalDatabaseService() => _instance;
 
   static const String _databaseName = 'petcare_offline.db';
-  static const int _databaseVersion = 1;
+  static const int _databaseVersion = 2;
 
   Database? _database;
 
@@ -96,6 +97,7 @@ class LocalDatabaseService {
       fullPath,
       version: _databaseVersion,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
       onConfigure: (db) async {
         await db.execute('PRAGMA foreign_keys = ON;');
       },
@@ -151,6 +153,8 @@ class LocalDatabaseService {
       )
     ''');
 
+    await _createLostPetsTable(db);
+
     await db.execute('''
       CREATE TABLE ${LocalDbTables.syncQueue} (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -179,6 +183,23 @@ class LocalDatabaseService {
     );
   }
 
+  Future<void> _onUpgrade(Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await _createLostPetsTable(db);
+    }
+  }
+
+  Future<void> _createLostPetsTable(Database db) async {
+    await db.execute('''
+      CREATE TABLE IF NOT EXISTS ${LocalDbTables.lostPets} (
+        remote_id TEXT PRIMARY KEY,
+        payload TEXT NOT NULL,
+        sync_status TEXT NOT NULL DEFAULT 'synced',
+        updated_at INTEGER NOT NULL
+      )
+    ''');
+  }
+
   Future<void> upsertEntity({
     required String table,
     required String remoteId,
@@ -187,16 +208,12 @@ class LocalDatabaseService {
     DateTime? updatedAt,
   }) async {
     final db = await database;
-    await db.insert(
-      table,
-      <String, Object?>{
-        'remote_id': remoteId,
-        'payload': jsonEncode(payload),
-        'sync_status': syncStatus,
-        'updated_at': (updatedAt ?? DateTime.now()).millisecondsSinceEpoch,
-      },
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    await db.insert(table, <String, Object?>{
+      'remote_id': remoteId,
+      'payload': jsonEncode(payload),
+      'sync_status': syncStatus,
+      'updated_at': (updatedAt ?? DateTime.now()).millisecondsSinceEpoch,
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
   Future<Map<String, dynamic>?> getEntityById({
@@ -295,7 +312,10 @@ class LocalDatabaseService {
     }
 
     final db = await database;
-    final placeholders = List<String>.filled(keepRemoteIds.length, '?').join(', ');
+    final placeholders = List<String>.filled(
+      keepRemoteIds.length,
+      '?',
+    ).join(', ');
     final where = StringBuffer('remote_id NOT IN ($placeholders)');
     final whereArgs = keepRemoteIds.cast<Object?>();
 
@@ -303,11 +323,7 @@ class LocalDatabaseService {
       where.write(" AND (sync_status IS NULL OR sync_status = 'synced')");
     }
 
-    await db.delete(
-      table,
-      where: where.toString(),
-      whereArgs: whereArgs,
-    );
+    await db.delete(table, where: where.toString(), whereArgs: whereArgs);
   }
 
   Future<void> clearUserData() async {
@@ -318,6 +334,8 @@ class LocalDatabaseService {
     batch.delete(LocalDbTables.events);
     batch.delete(LocalDbTables.vaccines);
     batch.delete(LocalDbTables.petVaccinations);
+    batch.delete(LocalDbTables.lostPets);
+    batch.delete(LocalDbTables.syncQueue);
     await batch.commit(noResult: true);
   }
 
@@ -329,10 +347,7 @@ class LocalDatabaseService {
   Future<SyncQueueSummary> getSyncQueueSummary({int maxRetries = 5}) async {
     final db = await database;
 
-    final totalCount = await _countRows(
-      db,
-      LocalDbTables.syncQueue,
-    );
+    final totalCount = await _countRows(db, LocalDbTables.syncQueue);
     final pendingCount = await _countRows(
       db,
       LocalDbTables.syncQueue,
@@ -436,10 +451,7 @@ class LocalDatabaseService {
     );
   }
 
-  Future<void> markSyncOperationFailed(
-    int operationId, {
-    String? error,
-  }) async {
+  Future<void> markSyncOperationFailed(int operationId, {String? error}) async {
     final db = await database;
     await db.rawUpdate(
       'UPDATE ${LocalDbTables.syncQueue} '
@@ -465,13 +477,15 @@ class LocalDatabaseService {
     );
   }
 
-  Future<void> setMetaValue({required String key, required String value}) async {
+  Future<void> setMetaValue({
+    required String key,
+    required String value,
+  }) async {
     final db = await database;
-    await db.insert(
-      LocalDbTables.appMeta,
-      <String, Object>{'key': key, 'value': value},
-      conflictAlgorithm: ConflictAlgorithm.replace,
-    );
+    await db.insert(LocalDbTables.appMeta, <String, Object>{
+      'key': key,
+      'value': value,
+    }, conflictAlgorithm: ConflictAlgorithm.replace);
   }
 
   Future<String?> getMetaValue(String key) async {

--- a/lib/core/services/location_service.dart
+++ b/lib/core/services/location_service.dart
@@ -1,0 +1,64 @@
+import 'package:geolocator/geolocator.dart';
+
+class AppLocation {
+  const AppLocation({
+    required this.latitude,
+    required this.longitude,
+    this.accuracyMeters,
+  });
+
+  final double latitude;
+  final double longitude;
+  final double? accuracyMeters;
+}
+
+class LocationService {
+  LocationService._();
+
+  static final LocationService _instance = LocationService._();
+
+  factory LocationService() => _instance;
+
+  Future<AppLocation> getCurrentLocation() async {
+    final serviceEnabled = await Geolocator.isLocationServiceEnabled();
+    if (!serviceEnabled) {
+      throw const LocationServiceException('Location services are disabled.');
+    }
+
+    var permission = await Geolocator.checkPermission();
+    if (permission == LocationPermission.denied) {
+      permission = await Geolocator.requestPermission();
+      if (permission == LocationPermission.denied) {
+        throw const LocationServiceException('Location permission was denied.');
+      }
+    }
+
+    if (permission == LocationPermission.deniedForever) {
+      throw const LocationServiceException(
+        'Location permission is permanently denied.',
+      );
+    }
+
+    final position = await Geolocator.getCurrentPosition(
+      locationSettings: const LocationSettings(
+        accuracy: LocationAccuracy.high,
+        timeLimit: Duration(seconds: 15),
+      ),
+    );
+
+    return AppLocation(
+      latitude: position.latitude,
+      longitude: position.longitude,
+      accuracyMeters: position.accuracy,
+    );
+  }
+}
+
+class LocationServiceException implements Exception {
+  const LocationServiceException(this.message);
+
+  final String message;
+
+  @override
+  String toString() => message;
+}

--- a/lib/core/services/lost_pet_service.dart
+++ b/lib/core/services/lost_pet_service.dart
@@ -1,0 +1,567 @@
+import 'dart:async';
+import 'dart:convert';
+
+import '../models/lost_pet_model.dart';
+import '../network/api_client.dart';
+import '../network/api_exception.dart';
+import 'local_database_service.dart';
+import 'response_cache_service.dart';
+
+class LostPetService {
+  LostPetService._();
+
+  static final LostPetService _instance = LostPetService._();
+
+  factory LostPetService() => _instance;
+
+  static const String lostPetsPath = '/api/lost-pets/';
+  static const String _lostPetsCacheKey = 'lost_pets.public';
+
+  static const String _entityTypeLostPetReport = 'lost_pet_report';
+  static const String _actionCreateReport = 'create_report';
+  static const String _actionUpdateReport = 'update_report';
+  static const String _actionResolveReport = 'resolve_report';
+  static const String _petIdMappingMetaPrefix = 'pet_id_map.';
+
+  final ApiClient _apiClient = ApiClient();
+  final ResponseCacheService _cache = ResponseCacheService();
+  final LocalDatabaseService _localDb = LocalDatabaseService();
+
+  Future<List<LostPetReportModel>> getLostPets({
+    bool forceRefresh = false,
+  }) async {
+    final cachedEntry = await _cache.get(_lostPetsCacheKey);
+
+    try {
+      final response = await _apiClient.get(lostPetsPath, authenticated: false);
+      final reports = _parseReports(response.body);
+      await _cache.set(_lostPetsCacheKey, response.body);
+      await _persistReportsFromBody(response.body);
+      return reports;
+    } catch (_) {
+      if (cachedEntry != null) {
+        final fallbackReports = _tryParseReports(cachedEntry.body);
+        if (fallbackReports != null) {
+          unawaited(_persistReportsFromBody(cachedEntry.body));
+          return fallbackReports;
+        }
+      }
+
+      final localReports = await _getReportsFromLocalDb();
+      if (localReports.isNotEmpty) {
+        return localReports;
+      }
+      rethrow;
+    }
+  }
+
+  Future<LostPetReportModel> getLostPetDetail(String reportId) async {
+    final trimmedReportId = reportId.trim();
+
+    try {
+      final response = await _apiClient.get(
+        '$lostPetsPath$trimmedReportId/',
+        authenticated: false,
+      );
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        throw const ApiException(
+          type: ApiErrorType.unknown,
+          message: 'Unexpected lost pet detail response from server.',
+        );
+      }
+
+      await _persistReportMap(_asMap(decoded));
+      return LostPetReportModel.fromJson(decoded);
+    } on ApiException catch (error) {
+      if (error.type != ApiErrorType.network) {
+        rethrow;
+      }
+
+      final localReport = await _localDb.getEntityById(
+        table: LocalDbTables.lostPets,
+        remoteId: trimmedReportId,
+      );
+      if (localReport != null &&
+          (localReport['status'] as String?) == 'active') {
+        return LostPetReportModel.fromJson(localReport);
+      }
+      rethrow;
+    }
+  }
+
+  Future<LostPetReportModel?> getOwnerLostReport(String petId) async {
+    final normalizedPetId = petId.trim();
+    try {
+      final response = await _apiClient.get(
+        '/api/pets/$normalizedPetId/lost-report/',
+      );
+      if (response.body.trim().isEmpty) {
+        return null;
+      }
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        return null;
+      }
+      await _persistReportMap(_asMap(decoded));
+      return LostPetReportModel.fromJson(decoded);
+    } on ApiException catch (error) {
+      if (error.statusCode == 404) {
+        return null;
+      }
+      rethrow;
+    }
+  }
+
+  Future<LostPetReportModel> saveOwnerLostReport({
+    required String petId,
+    required Map<String, dynamic> data,
+    bool isUpdate = false,
+  }) async {
+    final normalizedPetId = petId.trim();
+    try {
+      final response = isUpdate
+          ? await _apiClient.put(
+              '/api/pets/$normalizedPetId/lost-report/',
+              body: data,
+            )
+          : await _apiClient.post(
+              '/api/pets/$normalizedPetId/lost-report/',
+              body: data,
+            );
+      final decoded = jsonDecode(response.body);
+      if (decoded is! Map<String, dynamic>) {
+        throw const ApiException(
+          type: ApiErrorType.unknown,
+          message: 'Unexpected lost report response from server.',
+        );
+      }
+      await _persistReportMap(_asMap(decoded));
+      await _markLocalPetStatus(normalizedPetId, 'lost');
+      await _invalidateLostPetsCache();
+      await _invalidatePetCaches();
+      return LostPetReportModel.fromJson(decoded);
+    } catch (error) {
+      if (!_shouldQueueOffline(error)) {
+        rethrow;
+      }
+
+      final localReportId = _newLocalId('lost_report');
+      final pendingPayload = _buildPendingReportPayload(
+        source: data,
+        petId: normalizedPetId,
+        reportId: localReportId,
+      );
+      await _localDb.upsertEntity(
+        table: LocalDbTables.lostPets,
+        remoteId: localReportId,
+        payload: pendingPayload,
+        syncStatus: isUpdate ? 'pending_update' : 'pending_create',
+      );
+      await _localDb.enqueueSyncOperation(
+        entityType: _entityTypeLostPetReport,
+        entityId: localReportId,
+        action: isUpdate ? _actionUpdateReport : _actionCreateReport,
+        payload: <String, dynamic>{
+          'petId': normalizedPetId,
+          'data': _asMap(data),
+        },
+      );
+      await _markLocalPetStatus(normalizedPetId, 'lost');
+      await _invalidateLostPetsCache();
+      await _invalidatePetCaches();
+      return LostPetReportModel.fromJson(pendingPayload);
+    }
+  }
+
+  Future<void> markPetAsFound(String petId) async {
+    final normalizedPetId = petId.trim();
+    try {
+      final response = await _apiClient.post(
+        '/api/pets/$normalizedPetId/mark-found/',
+      );
+      await _persistResolvedReportFromMarkFoundResponse(response.body);
+      await _markLocalReportsForPetResolved(normalizedPetId);
+      await _markLocalPetStatus(normalizedPetId, 'healthy');
+      await _invalidateLostPetsCache();
+      await _invalidatePetCaches();
+    } catch (error) {
+      if (!_shouldQueueOffline(error)) {
+        rethrow;
+      }
+      await _markLocalReportsForPetResolved(normalizedPetId);
+      await _markLocalPetStatus(normalizedPetId, 'healthy');
+      await _localDb.enqueueSyncOperation(
+        entityType: _entityTypeLostPetReport,
+        entityId: normalizedPetId,
+        action: _actionResolveReport,
+        payload: <String, dynamic>{'petId': normalizedPetId},
+      );
+      await _invalidateLostPetsCache();
+      await _invalidatePetCaches();
+    }
+  }
+
+  Future<void> retryPendingSyncOperations({int limit = 30}) async {
+    final reportOperations = await _localDb.getPendingSyncOperations(
+      entityType: _entityTypeLostPetReport,
+      limit: limit,
+    );
+
+    for (final operation in reportOperations) {
+      try {
+        final payload = operation.payload ?? const <String, dynamic>{};
+        final petId = await _resolvePetIdForSync(
+          (payload['petId'] as String?)?.trim(),
+        );
+        if (petId.isEmpty) {
+          throw const ApiException(
+            type: ApiErrorType.unknown,
+            message: 'Missing petId in queued lost report operation.',
+          );
+        }
+
+        switch (operation.action) {
+          case _actionCreateReport:
+            final response = await _apiClient.post(
+              '/api/pets/$petId/lost-report/',
+              body: _asMap(payload['data']),
+            );
+            await _persistResponseReport(response.body);
+            await _deleteLocalPendingReport(operation.entityId);
+            break;
+          case _actionUpdateReport:
+            final response = await _apiClient.put(
+              '/api/pets/$petId/lost-report/',
+              body: _asMap(payload['data']),
+            );
+            await _persistResponseReport(response.body);
+            await _deleteLocalPendingReport(operation.entityId);
+            break;
+          case _actionResolveReport:
+            final response = await _apiClient.post(
+              '/api/pets/$petId/mark-found/',
+            );
+            await _persistResolvedReportFromMarkFoundResponse(response.body);
+            await _markLocalReportsForPetResolved(petId);
+            await _markLocalPetStatus(petId, 'healthy');
+            await _deleteLocalPendingReport(operation.entityId);
+            break;
+          default:
+            break;
+        }
+
+        await _localDb.markSyncOperationCompleted(operation.id);
+      } catch (error) {
+        await _localDb.markSyncOperationFailed(
+          operation.id,
+          error: error.toString(),
+        );
+      }
+    }
+  }
+
+  List<LostPetReportModel> _parseReports(String body) {
+    final decoded = jsonDecode(body);
+    if (decoded is! List<dynamic>) {
+      throw const ApiException(
+        type: ApiErrorType.unknown,
+        message: 'Unexpected lost pets response from server.',
+      );
+    }
+    return decoded
+        .map(_asMap)
+        .map(LostPetReportModel.fromJson)
+        .toList(growable: false);
+  }
+
+  List<LostPetReportModel>? _tryParseReports(String body) {
+    try {
+      return _parseReports(body);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Future<void> _persistResponseReport(String body) async {
+    if (body.trim().isEmpty) {
+      return;
+    }
+    final decoded = jsonDecode(body);
+    if (decoded is Map<String, dynamic>) {
+      await _persistReportMap(decoded);
+    } else if (decoded is Map) {
+      await _persistReportMap(_asMap(decoded));
+    }
+  }
+
+  Future<void> _persistReportsFromBody(String body) async {
+    try {
+      final decoded = jsonDecode(body);
+      if (decoded is! List<dynamic>) {
+        return;
+      }
+      final remoteIds = <String>[];
+      for (final item in decoded) {
+        final map = _asMap(item);
+        await _persistReportMap(map);
+        final remoteId = _readRemoteId(map);
+        if (remoteId != null) {
+          remoteIds.add(remoteId);
+        }
+      }
+      if (remoteIds.isNotEmpty) {
+        await _localDb.deleteEntitiesNotIn(
+          table: LocalDbTables.lostPets,
+          keepRemoteIds: remoteIds,
+        );
+      }
+    } catch (_) {
+      // Local persistence is best effort.
+    }
+  }
+
+  Future<void> _persistReportMap(Map<String, dynamic> reportJson) async {
+    final remoteId = _readRemoteId(reportJson);
+    if (remoteId == null) {
+      return;
+    }
+    await _localDb.upsertEntity(
+      table: LocalDbTables.lostPets,
+      remoteId: remoteId,
+      payload: reportJson,
+    );
+  }
+
+  Future<List<LostPetReportModel>> _getReportsFromLocalDb() async {
+    try {
+      final localRows = await _localDb.getAllEntities(LocalDbTables.lostPets);
+      return localRows
+          .where((row) => (row['status'] as String?) == 'active')
+          .map(LostPetReportModel.fromJson)
+          .toList(growable: false);
+    } catch (_) {
+      return const <LostPetReportModel>[];
+    }
+  }
+
+  Future<void> _invalidateLostPetsCache() async {
+    try {
+      await _cache.clear(_lostPetsCacheKey);
+    } catch (_) {
+      // Cache invalidation is best effort.
+    }
+  }
+
+  Future<void> _invalidatePetCaches() async {
+    try {
+      await _cache.clear('pets.mine');
+      await _cache.clear('users.current');
+    } catch (_) {
+      // Cache invalidation is best effort.
+    }
+  }
+
+  Future<void> _markLocalPetStatus(String petId, String status) async {
+    final normalizedPetId = petId.trim();
+    if (normalizedPetId.isEmpty) {
+      return;
+    }
+
+    try {
+      final petJson = await _localDb.getEntityById(
+        table: LocalDbTables.pets,
+        remoteId: normalizedPetId,
+      );
+      if (petJson == null) {
+        return;
+      }
+
+      final nextPetJson = <String, dynamic>{...petJson, 'status': status};
+      await _localDb.upsertEntity(
+        table: LocalDbTables.pets,
+        remoteId: normalizedPetId,
+        payload: nextPetJson,
+      );
+    } catch (_) {
+      // Local status sync is best effort.
+    }
+  }
+
+  Future<void> _persistResolvedReportFromMarkFoundResponse(String body) async {
+    if (body.trim().isEmpty) {
+      return;
+    }
+
+    try {
+      final decoded = jsonDecode(body);
+      final map = _asMap(decoded);
+      final report = map['report'];
+      if (report is Map) {
+        await _persistReportMap(_asMap(report));
+      }
+    } catch (_) {
+      // Local persistence is best effort.
+    }
+  }
+
+  Future<void> _markLocalReportsForPetResolved(String petId) async {
+    final normalizedPetId = petId.trim();
+    if (normalizedPetId.isEmpty) {
+      return;
+    }
+
+    try {
+      final localRows = await _localDb.getAllEntities(LocalDbTables.lostPets);
+      final now = DateTime.now().toIso8601String();
+      for (final row in localRows) {
+        final rowPetId = _readPetId(row);
+        if (rowPetId != normalizedPetId) {
+          continue;
+        }
+
+        final remoteId = _readRemoteId(row);
+        if (remoteId == null) {
+          continue;
+        }
+
+        await _localDb.upsertEntity(
+          table: LocalDbTables.lostPets,
+          remoteId: remoteId,
+          payload: <String, dynamic>{
+            ...row,
+            'status': 'resolved',
+            'resolvedAt': row['resolvedAt'] ?? row['resolved_at'] ?? now,
+          },
+        );
+      }
+    } catch (_) {
+      // Local report resolution is best effort.
+    }
+  }
+
+  Map<String, dynamic> _buildPendingReportPayload({
+    required Map<String, dynamic> source,
+    required String petId,
+    required String reportId,
+  }) {
+    final map = _asMap(source);
+    final lastSeen = _asMap(map['lastSeen'] ?? map['last_seen']);
+    return <String, dynamic>{
+      'id': reportId,
+      'petId': petId,
+      'ownerId': '',
+      'city': map['city'] ?? 'Bogotá',
+      'status': 'active',
+      'petName': map['petName'] ?? '',
+      'species': map['species'] ?? '',
+      'breed': map['breed'] ?? '',
+      'gender': map['gender'] ?? '',
+      'color': map['color'] ?? '',
+      'weight': map['weight'],
+      'photoUrl': map['photoUrl'],
+      'knownAllergies': map['knownAllergies'] ?? '',
+      'defaultVet': map['defaultVet'] ?? '',
+      'defaultClinic': map['defaultClinic'] ?? '',
+      'lostNote': map['lostNote'] ?? '',
+      'exposeMedicalInfo': map['exposeMedicalInfo'] ?? false,
+      'nfcNotificationsEnabled': map['nfcNotificationsEnabled'] ?? true,
+      'lastSeen': lastSeen.isNotEmpty
+          ? lastSeen
+          : {
+              'name': map['lastSeenLocation'] ?? map['last_seen_location'],
+              'latitude': map['lastSeenLatitude'] ?? map['last_seen_latitude'],
+              'longitude':
+                  map['lastSeenLongitude'] ?? map['last_seen_longitude'],
+              'seenAt': map['lastSeenAt'] ?? map['last_seen_at'],
+            },
+      'contacts':
+          map['contacts'] ?? map['emergencyContacts'] ?? const <dynamic>[],
+      'createdAt': DateTime.now().toIso8601String(),
+      'updatedAt': DateTime.now().toIso8601String(),
+    };
+  }
+
+  Map<String, dynamic> _asMap(dynamic item) {
+    if (item is Map<String, dynamic>) {
+      return item;
+    }
+    if (item is Map) {
+      return item.map((key, value) => MapEntry(key.toString(), value));
+    }
+    return const <String, dynamic>{};
+  }
+
+  String? _readRemoteId(Map<String, dynamic> json) {
+    final id = json['id'] ?? json['_id'];
+    if (id is String && id.trim().isNotEmpty) {
+      return id.trim();
+    }
+    if (id is Map) {
+      final oid = id['\$oid'];
+      if (oid is String && oid.trim().isNotEmpty) {
+        return oid.trim();
+      }
+    }
+    return null;
+  }
+
+  String? _readPetId(Map<String, dynamic> json) {
+    final petId = json['petId'] ?? json['pet_id'];
+    if (petId is String && petId.trim().isNotEmpty) {
+      return petId.trim();
+    }
+
+    final pet = json['pet'];
+    if (pet is Map) {
+      final id = pet['id'] ?? pet['_id'];
+      if (id is String && id.trim().isNotEmpty) {
+        return id.trim();
+      }
+      if (id is Map) {
+        final oid = id['\$oid'];
+        if (oid is String && oid.trim().isNotEmpty) {
+          return oid.trim();
+        }
+      }
+    }
+
+    return null;
+  }
+
+  String _newLocalId(String prefix) {
+    return 'local_${prefix}_${DateTime.now().millisecondsSinceEpoch}';
+  }
+
+  Future<String> _resolvePetIdForSync(String? petId) async {
+    final trimmed = petId?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return '';
+    }
+
+    final mapped = await _localDb.getMetaValue(
+      '$_petIdMappingMetaPrefix$trimmed',
+    );
+    final mappedTrimmed = mapped?.trim() ?? '';
+    return mappedTrimmed.isNotEmpty ? mappedTrimmed : trimmed;
+  }
+
+  Future<void> _deleteLocalPendingReport(String reportId) async {
+    final normalized = reportId.trim();
+    if (!normalized.startsWith('local_')) {
+      return;
+    }
+    try {
+      await _localDb.deleteEntity(
+        table: LocalDbTables.lostPets,
+        remoteId: normalized,
+      );
+    } catch (_) {
+      // Best effort cleanup after a queued report sync succeeds.
+    }
+  }
+
+  bool _shouldQueueOffline(Object error) {
+    return error is ApiException && error.type == ApiErrorType.network;
+  }
+}

--- a/lib/core/services/map_tile_cache_service.dart
+++ b/lib/core/services/map_tile_cache_service.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+class MapTileCacheService {
+  MapTileCacheService._();
+
+  static const String userAgentPackageName = 'com.example.petcare';
+  static const String osmTileUrlTemplate =
+      'https://tile.openstreetmap.org/{z}/{x}/{y}.png';
+
+  static final LatLngBounds bogotaBounds = LatLngBounds(
+    const LatLng(4.45, -74.24),
+    const LatLng(4.84, -73.98),
+  );
+}

--- a/lib/core/services/nfc_backend_service.dart
+++ b/lib/core/services/nfc_backend_service.dart
@@ -32,6 +32,27 @@ class NfcBackendService {
     );
   }
 
+  Future<Map<String, dynamic>> recordNfcLostPetSighting({
+    required String petId,
+    required Map<String, dynamic> data,
+  }) async {
+    final normalizedPetId = petId.trim();
+    if (normalizedPetId.isEmpty) {
+      throw const ApiException(
+        type: ApiErrorType.unknown,
+        message: 'Missing pet id to record NFC sighting.',
+      );
+    }
+
+    final response = await _apiClient.post(
+      '/api/nfc/read/$normalizedPetId/sighting/',
+      body: data,
+      authenticated: false,
+    );
+
+    return _decodeOptionalMap(response.body);
+  }
+
   Future<Map<String, dynamic>> getWritePayload(String petId) async {
     final normalizedPetId = petId.trim();
     if (normalizedPetId.isEmpty) {
@@ -41,7 +62,9 @@ class NfcBackendService {
       );
     }
 
-    final response = await _apiClient.get('/api/pets/$normalizedPetId/nfc-payload/');
+    final response = await _apiClient.get(
+      '/api/pets/$normalizedPetId/nfc-payload/',
+    );
 
     return _decodeRequiredMap(
       response.body,
@@ -58,7 +81,9 @@ class NfcBackendService {
       );
     }
 
-    final response = await _apiClient.post('/api/pets/$normalizedPetId/nfc-sync/');
+    final response = await _apiClient.post(
+      '/api/pets/$normalizedPetId/nfc-sync/',
+    );
     return _decodeOptionalMap(response.body);
   }
 
@@ -71,10 +96,7 @@ class NfcBackendService {
       return decoded;
     }
 
-    throw ApiException(
-      type: ApiErrorType.unknown,
-      message: fallbackMessage,
-    );
+    throw ApiException(type: ApiErrorType.unknown, message: fallbackMessage);
   }
 
   Map<String, dynamic> _decodeOptionalMap(String body) {

--- a/lib/core/services/notification_service.dart
+++ b/lib/core/services/notification_service.dart
@@ -1,0 +1,35 @@
+import 'dart:convert';
+
+import '../models/notification_model.dart';
+import '../network/api_client.dart';
+import 'user_service.dart';
+
+class NotificationService {
+  NotificationService._();
+
+  static final NotificationService _instance = NotificationService._();
+
+  factory NotificationService() => _instance;
+
+  final ApiClient _apiClient = ApiClient();
+  final UserService _userService = UserService();
+
+  Future<List<NotificationModel>> getMyNotifications() async {
+    final user = await _userService.getCurrentUser();
+    final userId = Uri.encodeComponent(user.id);
+    final response = await _apiClient.get(
+      '/api/notifications/?user_id=$userId',
+    );
+    final decoded = jsonDecode(response.body);
+    if (decoded is! List) {
+      return const <NotificationModel>[];
+    }
+    return decoded
+        .whereType<Map>()
+        .map(
+          (item) => item.map((key, value) => MapEntry(key.toString(), value)),
+        )
+        .map(NotificationModel.fromJson)
+        .toList(growable: false);
+  }
+}

--- a/lib/core/services/sync_retry_service.dart
+++ b/lib/core/services/sync_retry_service.dart
@@ -1,4 +1,5 @@
 import 'attachment_upload_service.dart';
+import 'lost_pet_service.dart';
 import 'pet_service.dart';
 import 'event_service.dart';
 import 'user_service.dart';
@@ -13,6 +14,7 @@ class SyncRetryService {
   final PetService _petService = PetService();
   final EventService _eventService = EventService();
   final UserService _userService = UserService();
+  final LostPetService _lostPetService = LostPetService();
   final AttachmentUploadService _attachmentUploadService =
       AttachmentUploadService();
 
@@ -22,6 +24,7 @@ class SyncRetryService {
     );
     await _userService.retryPendingSyncOperations(limit: limitPerEntity);
     await _petService.retryPendingSyncOperations(limit: limitPerEntity);
+    await _lostPetService.retryPendingSyncOperations(limit: limitPerEntity);
     await _eventService.retryPendingSyncOperations(limit: limitPerEntity);
   }
 }

--- a/lib/presentation/pages/lost_pets/lost_pet_detail_page.dart
+++ b/lib/presentation/pages/lost_pets/lost_pet_detail_page.dart
@@ -1,0 +1,919 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../app/routes.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/constants/app_dimensions.dart';
+import '../../../core/constants/app_strings.dart';
+import '../../../core/models/lost_pet_model.dart';
+import '../../../core/services/app_image_cache_manager.dart';
+import '../../../core/services/lost_pet_service.dart';
+import '../../../shared/widgets/lost_pet_map_preview.dart';
+import '../../../shared/widgets/petcare_bottom_nav_bar.dart';
+
+class LostPetDetailPage extends StatefulWidget {
+  const LostPetDetailPage({super.key, required this.initialReport});
+
+  final LostPetReportModel initialReport;
+
+  @override
+  State<LostPetDetailPage> createState() => _LostPetDetailPageState();
+}
+
+class _LostPetDetailPageState extends State<LostPetDetailPage> {
+  final LostPetService _lostPetService = LostPetService();
+
+  late LostPetReportModel _report;
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _report = widget.initialReport;
+    _loadDetail();
+  }
+
+  Future<void> _loadDetail() async {
+    setState(() => _isLoading = true);
+
+    try {
+      final report = await _lostPetService.getLostPetDetail(_report.id);
+      if (!mounted) {
+        return;
+      }
+      setState(() => _report = report);
+    } catch (_) {
+      // The list card payload is enough for an offline fallback.
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _callContact() async {
+    final phone = _report.primaryContact?.phone.trim() ?? '';
+    if (phone.isEmpty) {
+      return;
+    }
+    await launchUrl(Uri(scheme: 'tel', path: phone));
+  }
+
+  Future<void> _openWhatsApp() async {
+    final phone = _report.primaryContact?.whatsapp.trim() ?? '';
+    if (phone.isEmpty) {
+      return;
+    }
+    final normalizedPhone = phone.replaceAll(RegExp(r'[^0-9+]'), '');
+    await launchUrl(
+      Uri.parse('https://wa.me/$normalizedPhone'),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  void _handleBottomNavTap(int index) {
+    final routeName = Routes.bottomNavRouteForIndex(index);
+    if (routeName == null) {
+      return;
+    }
+    Navigator.of(context).pushReplacementNamed(routeName);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final contact = _report.primaryContact;
+    final canCall =
+        contact?.allowCall == true && contact!.phone.trim().isNotEmpty;
+    final canWhatsApp =
+        contact?.allowWhatsApp == true && contact!.whatsapp.trim().isNotEmpty;
+
+    return Scaffold(
+      backgroundColor: Theme.of(context).brightness == Brightness.dark
+          ? AppColors.backgroundDark
+          : AppColors.background,
+      appBar: AppBar(
+        title: const Text(AppStrings.lostPetDetailTitle),
+        centerTitle: true,
+        actions: _isLoading
+            ? [
+                const Padding(
+                  padding: EdgeInsets.only(right: AppDimensions.spaceM),
+                  child: Center(
+                    child: SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    ),
+                  ),
+                ),
+              ]
+            : null,
+      ),
+      body: ListView(
+        padding: const EdgeInsets.fromLTRB(
+          AppDimensions.pageHorizontalPadding,
+          AppDimensions.spaceM,
+          AppDimensions.pageHorizontalPadding,
+          AppDimensions.spaceL,
+        ),
+        children: [
+          _PhotoHeader(report: _report),
+          const SizedBox(height: AppDimensions.spaceM),
+          _LastSeenCard(report: _report),
+          const SizedBox(height: AppDimensions.spaceM),
+          if (_report.knownAllergies.trim().isNotEmpty) ...[
+            _MedicalInfoCard(report: _report),
+            const SizedBox(height: AppDimensions.spaceM),
+          ],
+          _SpecsGrid(report: _report),
+          if (contact != null) ...[
+            const SizedBox(height: AppDimensions.spaceM),
+            _OwnerContactCard(contact: contact),
+          ],
+          if (_report.contacts.length > 1) ...[
+            const SizedBox(height: AppDimensions.spaceM),
+            _OwnerContactCard(
+              contact: _report.contacts[1],
+              title: AppStrings.lostPetEmergencyContacts,
+            ),
+          ],
+        ],
+      ),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (canCall || canWhatsApp)
+            _ContactActionsBar(
+              canCall: canCall,
+              canWhatsApp: canWhatsApp,
+              onCall: _callContact,
+              onWhatsApp: _openWhatsApp,
+            ),
+          PetcareBottomNavBar(currentIndex: 2, onTap: _handleBottomNavTap),
+        ],
+      ),
+    );
+  }
+}
+
+class _PhotoHeader extends StatelessWidget {
+  const _PhotoHeader({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(18),
+      child: AspectRatio(
+        aspectRatio: 16 / 10,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            _PetPhoto(photoUrl: report.photoUrl, isDark: isDark),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.04),
+                    Colors.black.withValues(alpha: 0.64),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              left: AppDimensions.spaceM,
+              top: AppDimensions.spaceM,
+              child: _LostBadge(report: report, isDark: isDark),
+            ),
+            Positioned(
+              left: AppDimensions.spaceM,
+              right: AppDimensions.spaceM,
+              bottom: AppDimensions.spaceM,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    report.petName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      color: AppColors.onPrimary,
+                      fontWeight: FontWeight.w800,
+                      height: 1.05,
+                    ),
+                  ),
+                  const SizedBox(height: AppDimensions.spaceXS),
+                  Text(
+                    _headline(report),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: AppColors.onPrimary.withValues(alpha: 0.94),
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                  const SizedBox(height: AppDimensions.spaceS),
+                  Wrap(
+                    spacing: AppDimensions.spaceS,
+                    runSpacing: AppDimensions.spaceXS,
+                    children: [
+                      if (report.gender.trim().isNotEmpty)
+                        _HeroChip(label: report.gender.trim()),
+                      if (report.ageLabel.trim().isNotEmpty)
+                        _HeroChip(label: report.ageLabel.trim()),
+                      if (report.weight != null)
+                        _HeroChip(
+                          label: '${report.weight!.toStringAsFixed(1)} kg',
+                        ),
+                      if (report.color.trim().isNotEmpty)
+                        _HeroChip(label: report.color.trim()),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _headline(LostPetReportModel report) {
+    final parts = [
+      report.breed.trim().isEmpty ? report.species : report.breed,
+      report.species,
+    ].where((part) => part.trim().isNotEmpty).toList();
+    return parts.join(' · ');
+  }
+}
+
+class _PetPhoto extends StatelessWidget {
+  const _PetPhoto({required this.photoUrl, required this.isDark});
+
+  final String? photoUrl;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = photoUrl?.trim();
+    if (url == null || url.isEmpty) {
+      return _PetPhotoPlaceholder(isDark: isDark);
+    }
+    return CachedNetworkImage(
+      imageUrl: url,
+      cacheManager: AppImageCacheManager.instance,
+      fit: BoxFit.cover,
+      placeholder: (_, _) => _PetPhotoPlaceholder(isDark: isDark),
+      errorWidget: (_, _, _) => _PetPhotoPlaceholder(isDark: isDark),
+    );
+  }
+}
+
+class _PetPhotoPlaceholder extends StatelessWidget {
+  const _PetPhotoPlaceholder({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: isDark
+          ? AppColors.petCardQuickActionBgDark
+          : AppColors.petCardQuickActionBg,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.pets_rounded,
+        size: AppDimensions.iconXL,
+        color: isDark
+            ? AppColors.quickActionIconTintDark
+            : AppColors.quickActionIconTint,
+      ),
+    );
+  }
+}
+
+class _LostBadge extends StatelessWidget {
+  const _LostBadge({required this.report, required this.isDark});
+
+  final LostPetReportModel report;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final textColor = isDark
+        ? AppColors.negativeTextDark
+        : AppColors.negativeText;
+    final ageText = _timeAgo(report.createdAt ?? report.lastSeen.seenAt);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.negativeBackgroundDark
+            : AppColors.petStatusLostBg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            AppStrings.petDetailStatusLost.toUpperCase(),
+            style: TextStyle(
+              color: textColor,
+              fontSize: 12,
+              fontWeight: FontWeight.w800,
+              height: 1,
+            ),
+          ),
+          if (ageText.isNotEmpty) ...[
+            const SizedBox(width: 7),
+            Icon(Icons.schedule_rounded, size: 13, color: textColor),
+            const SizedBox(width: 3),
+            Text(
+              ageText,
+              style: TextStyle(
+                color: textColor,
+                fontSize: 12,
+                fontWeight: FontWeight.w700,
+                height: 1,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _HeroChip extends StatelessWidget {
+  const _HeroChip({required this.label});
+
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.24),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: AppColors.onPrimary,
+          fontWeight: FontWeight.w700,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _LastSeenCard extends StatelessWidget {
+  const _LastSeenCard({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = isDark
+        ? AppColors.smartAlertInfoBgDark
+        : AppColors.infoBackground;
+    final foregroundColor = isDark
+        ? AppColors.smartAlertInfoTextDark
+        : AppColors.infoText;
+    final iconBackgroundColor = isDark
+        ? AppColors.petCardQuickActionBgDark
+        : const Color(0xFF8FCAFF);
+    final locationName = report.lastSeen.name.trim().isEmpty
+        ? 'Bogotá'
+        : report.lastSeen.name.trim();
+    final seenAt = _formatDate(report.lastSeen.seenAt ?? report.createdAt);
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 46,
+                height: 46,
+                decoration: BoxDecoration(
+                  color: iconBackgroundColor,
+                  shape: BoxShape.circle,
+                ),
+                child: Icon(Icons.location_on_outlined, color: foregroundColor),
+              ),
+              const SizedBox(width: AppDimensions.spaceM),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      AppStrings.lostPetLastSeen,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: foregroundColor,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
+                      ),
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      locationName,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: foregroundColor,
+                        fontWeight: FontWeight.w800,
+                        height: 1.1,
+                      ),
+                    ),
+                    if (seenAt.isNotEmpty) ...[
+                      const SizedBox(height: 4),
+                      Text(
+                        seenAt,
+                        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: foregroundColor,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  ],
+                ),
+              ),
+            ],
+          ),
+          if (report.lastSeen.hasCoordinates) ...[
+            const SizedBox(height: AppDimensions.spaceM),
+            LostPetMapPreview(
+              latitude: report.lastSeen.latitude,
+              longitude: report.lastSeen.longitude,
+              height: 148,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _MedicalInfoCard extends StatelessWidget {
+  const _MedicalInfoCard({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final contentColor = isDark
+        ? AppColors.overdueCardContentDark
+        : AppColors.overdueCardContent;
+    final allergies = report.knownAllergies.trim();
+
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.overdueCardBackgroundDark
+            : AppColors.overdueCardBackground,
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: isDark
+              ? AppColors.overdueCardBorderDark
+              : AppColors.overdueCardContent,
+          width: 1.1,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(Icons.warning_amber_rounded, color: contentColor, size: 20),
+              const SizedBox(width: AppDimensions.spaceS),
+              Text(
+                AppStrings.lostPetMedicalInfo,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: contentColor,
+                  fontWeight: FontWeight.w800,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppDimensions.spaceM),
+          _MedicalLabel(text: 'Allergies:', color: contentColor),
+          const SizedBox(height: AppDimensions.spaceXS),
+          _MedicalPill(text: allergies),
+        ],
+      ),
+    );
+  }
+}
+
+class _MedicalLabel extends StatelessWidget {
+  const _MedicalLabel({required this.text, required this.color});
+
+  final String text;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Text(
+      text,
+      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+        color: color,
+        fontWeight: FontWeight.w800,
+      ),
+    );
+  }
+}
+
+class _MedicalPill extends StatelessWidget {
+  const _MedicalPill({required this.text});
+
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 5),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.overdueCardBorderDark
+            : const Color(0xFFFFC878),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        text,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: isDark
+              ? AppColors.overdueCardContentDark
+              : AppColors.overdueCardContent,
+          fontWeight: FontWeight.w700,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _SpecsGrid extends StatelessWidget {
+  const _SpecsGrid({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    final specs = [
+      _SpecItem('Species', report.species),
+      _SpecItem('Breed', report.breed),
+      _SpecItem('Color', report.color),
+      if (report.weight != null)
+        _SpecItem('Weight', '${report.weight!.toStringAsFixed(1)} kg'),
+      if (report.microchipId.trim().isNotEmpty)
+        _SpecItem('Microchip ID', report.microchipId.trim()),
+    ].where((item) => item.value.trim().isNotEmpty).toList();
+
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        final itemWidth = (constraints.maxWidth - AppDimensions.spaceS) / 2;
+        return Wrap(
+          spacing: AppDimensions.spaceS,
+          runSpacing: AppDimensions.spaceS,
+          children: specs
+              .map(
+                (item) => SizedBox(
+                  width: itemWidth,
+                  child: _SpecTile(item: item),
+                ),
+              )
+              .toList(growable: false),
+        );
+      },
+    );
+  }
+}
+
+class _SpecItem {
+  const _SpecItem(this.label, this.value);
+
+  final String label;
+  final String value;
+}
+
+class _SpecTile extends StatelessWidget {
+  const _SpecTile({required this.item});
+
+  final _SpecItem item;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      constraints: const BoxConstraints(minHeight: 78),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardQuickActionBg,
+        borderRadius: BorderRadius.circular(16),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Text(
+            item.label,
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+          const SizedBox(height: 3),
+          Text(
+            item.value,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: isDark ? AppColors.onSurfaceDark : AppColors.grey900,
+              fontWeight: FontWeight.w800,
+              height: 1.15,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OwnerContactCard extends StatelessWidget {
+  const _OwnerContactCard({
+    required this.contact,
+    this.title = AppStrings.lostPetOwnerContact,
+  });
+
+  final LostPetContactModel contact;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardBackground,
+        borderRadius: BorderRadius.circular(18),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.16 : 0.05),
+            blurRadius: 14,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title.toUpperCase(),
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+              fontWeight: FontWeight.w800,
+              letterSpacing: 0,
+            ),
+          ),
+          const SizedBox(height: AppDimensions.spaceM),
+          Row(
+            children: [
+              CircleAvatar(
+                radius: 22,
+                backgroundColor: AppColors.primaryVariant,
+                foregroundColor: AppColors.primary,
+                child: Text(
+                  _initials(contact.name),
+                  style: const TextStyle(fontWeight: FontWeight.w800),
+                ),
+              ),
+              const SizedBox(width: AppDimensions.spaceM),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      contact.name,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                        color: isDark
+                            ? AppColors.onSurfaceDark
+                            : AppColors.grey900,
+                        fontWeight: FontWeight.w800,
+                      ),
+                    ),
+                    Text(
+                      contact.relationship,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: isDark
+                            ? AppColors.onSurfaceDark
+                            : AppColors.grey700,
+                        fontWeight: FontWeight.w500,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppDimensions.spaceM),
+          if (contact.allowCall && contact.phone.trim().isNotEmpty)
+            _ContactInfoPill(icon: Icons.call_outlined, text: contact.phone),
+          if (contact.allowWhatsApp && contact.whatsapp.trim().isNotEmpty) ...[
+            const SizedBox(height: AppDimensions.spaceS),
+            const _ContactInfoPill(
+              icon: Icons.chat_bubble_outline_rounded,
+              text: AppStrings.lostPetWhatsApp,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  String _initials(String value) {
+    final parts = value
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) {
+      return '?';
+    }
+    return parts.take(2).map((part) => part[0].toUpperCase()).join();
+  }
+}
+
+class _ContactInfoPill extends StatelessWidget {
+  const _ContactInfoPill({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardQuickActionBgDark
+            : AppColors.petCardQuickActionBg,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Row(
+        children: [
+          Icon(icon, size: 16, color: AppColors.primary),
+          const SizedBox(width: AppDimensions.spaceS),
+          Expanded(
+            child: Text(
+              text,
+              maxLines: 1,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                color: isDark ? AppColors.onSurfaceDark : AppColors.grey900,
+                fontWeight: FontWeight.w800,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ContactActionsBar extends StatelessWidget {
+  const _ContactActionsBar({
+    required this.canCall,
+    required this.canWhatsApp,
+    required this.onCall,
+    required this.onWhatsApp,
+  });
+
+  final bool canCall;
+  final bool canWhatsApp;
+  final VoidCallback onCall;
+  final VoidCallback onWhatsApp;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+      ),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.bottomNavBackgroundDark
+            : AppColors.bottomNavBackground,
+        border: Border(
+          top: BorderSide(
+            color: isDark
+                ? AppColors.bottomNavTopBorderDark
+                : AppColors.bottomNavTopBorder,
+          ),
+        ),
+      ),
+      child: Row(
+        children: [
+          if (canCall)
+            Expanded(
+              child: SizedBox(
+                height: 52,
+                child: FilledButton.icon(
+                  onPressed: onCall,
+                  icon: const Icon(Icons.call_rounded),
+                  label: const Text(AppStrings.lostPetCall),
+                ),
+              ),
+            ),
+          if (canCall && canWhatsApp)
+            const SizedBox(width: AppDimensions.spaceM),
+          if (canWhatsApp)
+            Expanded(
+              child: SizedBox(
+                height: 52,
+                child: FilledButton.icon(
+                  onPressed: onWhatsApp,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: const Color(0xFF25D366),
+                    foregroundColor: AppColors.onPrimary,
+                  ),
+                  icon: const Icon(Icons.chat_bubble_outline_rounded),
+                  label: const Text(AppStrings.lostPetWhatsApp),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+String _formatDate(DateTime? value) {
+  if (value == null || value.year <= 1) {
+    return '';
+  }
+
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  return '${months[value.month - 1]} ${value.day}, ${value.year}';
+}
+
+String _timeAgo(DateTime? value) {
+  if (value == null || value.year <= 1) {
+    return '';
+  }
+
+  final difference = DateTime.now().difference(value);
+  if (difference.inDays >= 1) {
+    final days = difference.inDays;
+    return '$days day${days == 1 ? '' : 's'} ago';
+  }
+  if (difference.inHours >= 1) {
+    final hours = difference.inHours;
+    return '$hours hour${hours == 1 ? '' : 's'} ago';
+  }
+  return 'Today';
+}

--- a/lib/presentation/pages/lost_pets/lost_pet_sighting_detail_page.dart
+++ b/lib/presentation/pages/lost_pets/lost_pet_sighting_detail_page.dart
@@ -1,0 +1,504 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../app/routes.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/constants/app_dimensions.dart';
+import '../../../core/constants/app_strings.dart';
+import '../../../core/models/lost_pet_model.dart';
+import '../../../core/models/notification_model.dart';
+import '../../../core/services/app_image_cache_manager.dart';
+import '../../../core/services/lost_pet_service.dart';
+import '../../../shared/widgets/lost_pet_map_preview.dart';
+import '../../../shared/widgets/petcare_bottom_nav_bar.dart';
+
+class LostPetSightingDetailArgs {
+  const LostPetSightingDetailArgs({required this.notification});
+
+  final NotificationModel notification;
+}
+
+class LostPetSightingDetailPage extends StatefulWidget {
+  const LostPetSightingDetailPage({super.key, required this.notification});
+
+  final NotificationModel notification;
+
+  @override
+  State<LostPetSightingDetailPage> createState() =>
+      _LostPetSightingDetailPageState();
+}
+
+class _LostPetSightingDetailPageState extends State<LostPetSightingDetailPage> {
+  final LostPetService _lostPetService = LostPetService();
+
+  LostPetReportModel? _report;
+  bool _isLoading = true;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadReport();
+  }
+
+  Future<void> _loadReport() async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final report = await _lostPetService.getLostPetDetail(
+        widget.notification.actionReportId,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() => _report = report);
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() => _errorMessage = AppStrings.lostPetsLoadError);
+    } finally {
+      if (mounted) {
+        setState(() => _isLoading = false);
+      }
+    }
+  }
+
+  Future<void> _callScanner() async {
+    final phone = widget.notification.actionPhone.trim();
+    if (phone.isEmpty) {
+      return;
+    }
+    await launchUrl(Uri(scheme: 'tel', path: phone));
+  }
+
+  Future<void> _openScannerWhatsApp() async {
+    final phone = widget.notification.actionWhatsapp.trim();
+    if (phone.isEmpty) {
+      return;
+    }
+    final normalizedPhone = phone.replaceAll(RegExp(r'[^0-9+]'), '');
+    await launchUrl(
+      Uri.parse('https://wa.me/$normalizedPhone'),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  void _handleBottomNavTap(int index) {
+    final routeName = Routes.bottomNavRouteForIndex(index);
+    if (routeName == null) {
+      return;
+    }
+    Navigator.of(context).pushReplacementNamed(routeName);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final canCall = widget.notification.hasCallAction;
+    final canWhatsApp = widget.notification.hasWhatsAppAction;
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Lost pet update'), centerTitle: true),
+      body: _buildBody(),
+      bottomNavigationBar: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (canCall || canWhatsApp)
+            _ScannerActionsBar(
+              canCall: canCall,
+              canWhatsApp: canWhatsApp,
+              onCall: _callScanner,
+              onWhatsApp: _openScannerWhatsApp,
+            ),
+          PetcareBottomNavBar(currentIndex: 2, onTap: _handleBottomNavTap),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final hasNotificationSnapshot =
+        widget.notification.actionPetName.trim().isNotEmpty ||
+        widget.notification.actionPetPhotoUrl.trim().isNotEmpty ||
+        widget.notification.actionLocation.trim().isNotEmpty;
+    if ((_errorMessage != null || _report == null) &&
+        !hasNotificationSnapshot) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.all(AppDimensions.spaceXL),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Icon(
+                Icons.location_off_rounded,
+                size: 54,
+                color: AppColors.grey300,
+              ),
+              const SizedBox(height: AppDimensions.spaceM),
+              Text(
+                _errorMessage ?? AppStrings.lostPetsLoadError,
+                textAlign: TextAlign.center,
+              ),
+              const SizedBox(height: AppDimensions.spaceM),
+              OutlinedButton(
+                onPressed: _loadReport,
+                child: const Text(AppStrings.lostPetsRetry),
+              ),
+            ],
+          ),
+        ),
+      );
+    }
+
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceXL,
+      ),
+      children: [
+        _SightingHero(report: _report, notification: widget.notification),
+        const SizedBox(height: AppDimensions.spaceM),
+        _UpdatedLocationCard(
+          notification: widget.notification,
+          report: _report,
+        ),
+        const SizedBox(height: AppDimensions.spaceM),
+        _SightingTimeCard(notification: widget.notification),
+        const SizedBox(height: AppDimensions.spaceM),
+        _ScannerContactCard(notification: widget.notification),
+      ],
+    );
+  }
+}
+
+class _SightingHero extends StatelessWidget {
+  const _SightingHero({required this.report, required this.notification});
+
+  final LostPetReportModel? report;
+  final NotificationModel notification;
+
+  @override
+  Widget build(BuildContext context) {
+    final photoUrl = report?.photoUrl?.trim().isNotEmpty == true
+        ? report!.photoUrl!.trim()
+        : notification.actionPetPhotoUrl.trim();
+    final petName = report?.petName.trim().isNotEmpty == true
+        ? report!.petName.trim()
+        : notification.actionPetName.trim().isNotEmpty
+        ? notification.actionPetName.trim()
+        : 'Lost pet';
+    final subtitle = [
+      report?.breed ?? '',
+      report?.species ?? '',
+    ].where((value) => value.trim().isNotEmpty).join(' - ');
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(18),
+      child: AspectRatio(
+        aspectRatio: 16 / 10,
+        child: Stack(
+          fit: StackFit.expand,
+          children: [
+            if (photoUrl.isNotEmpty)
+              CachedNetworkImage(
+                imageUrl: photoUrl,
+                cacheManager: AppImageCacheManager.instance,
+                fit: BoxFit.cover,
+              )
+            else
+              Container(color: AppColors.primaryVariant),
+            DecoratedBox(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  begin: Alignment.topCenter,
+                  end: Alignment.bottomCenter,
+                  colors: [
+                    Colors.black.withValues(alpha: 0.06),
+                    Colors.black.withValues(alpha: 0.66),
+                  ],
+                ),
+              ),
+            ),
+            Positioned(
+              left: AppDimensions.spaceM,
+              right: AppDimensions.spaceM,
+              bottom: AppDimensions.spaceM,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    petName,
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                    style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                      color: AppColors.onPrimary,
+                      fontWeight: FontWeight.w800,
+                    ),
+                  ),
+                  if (subtitle.isNotEmpty)
+                    Text(
+                      subtitle,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: AppColors.onPrimary.withValues(alpha: 0.94),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _UpdatedLocationCard extends StatelessWidget {
+  const _UpdatedLocationCard({
+    required this.notification,
+    required this.report,
+  });
+
+  final NotificationModel notification;
+  final LostPetReportModel? report;
+
+  @override
+  Widget build(BuildContext context) {
+    final location = notification.actionLocation.trim().isNotEmpty
+        ? notification.actionLocation.trim()
+        : report?.lastSeen.name ?? '';
+    final latitude = notification.actionLatitude ?? report?.lastSeen.latitude;
+    final longitude =
+        notification.actionLongitude ?? report?.lastSeen.longitude;
+
+    return _SurfaceCard(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              const Icon(Icons.location_on_outlined, color: AppColors.primary),
+              const SizedBox(width: AppDimensions.spaceS),
+              Expanded(
+                child: Text(
+                  'Location updated',
+                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w800,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppDimensions.spaceS),
+          Text(
+            location.isEmpty ? AppStrings.valueNotAvailable : location,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: AppColors.grey700,
+              fontWeight: FontWeight.w700,
+            ),
+          ),
+          if (latitude != null && longitude != null) ...[
+            const SizedBox(height: AppDimensions.spaceM),
+            LostPetMapPreview(
+              latitude: latitude,
+              longitude: longitude,
+              height: 172,
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _ScannerContactCard extends StatelessWidget {
+  const _ScannerContactCard({required this.notification});
+
+  final NotificationModel notification;
+
+  @override
+  Widget build(BuildContext context) {
+    final phone = notification.actionPhone.trim();
+    final reporterName = notification.actionReporterName.trim();
+    return _SurfaceCard(
+      child: Row(
+        children: [
+          const CircleAvatar(
+            radius: 22,
+            backgroundColor: AppColors.primaryVariant,
+            foregroundColor: AppColors.primary,
+            child: Icon(Icons.person_outline_rounded),
+          ),
+          const SizedBox(width: AppDimensions.spaceM),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  reporterName.isEmpty ? 'NFC scanner' : reporterName,
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  phone.isEmpty ? 'No contact shared' : phone,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.grey700,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SightingTimeCard extends StatelessWidget {
+  const _SightingTimeCard({required this.notification});
+
+  final NotificationModel notification;
+
+  @override
+  Widget build(BuildContext context) {
+    final value = notification.dateSent;
+    return _SurfaceCard(
+      child: Row(
+        children: [
+          const Icon(Icons.access_time_rounded, color: AppColors.primary),
+          const SizedBox(width: AppDimensions.spaceM),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Scan time',
+                  style: Theme.of(
+                    context,
+                  ).textTheme.bodyLarge?.copyWith(fontWeight: FontWeight.w800),
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  value == null ? AppStrings.valueNotAvailable : _format(value),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.grey700,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  String _format(DateTime value) {
+    final local = value.toLocal();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return '${local.day}/${local.month}/${local.year} $hour:$minute';
+  }
+}
+
+class _SurfaceCard extends StatelessWidget {
+  const _SurfaceCard({required this.child});
+
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardBackground,
+        borderRadius: BorderRadius.circular(18),
+        border: Border.all(
+          color: isDark ? AppColors.grey700 : AppColors.grey300,
+        ),
+      ),
+      child: child,
+    );
+  }
+}
+
+class _ScannerActionsBar extends StatelessWidget {
+  const _ScannerActionsBar({
+    required this.canCall,
+    required this.canWhatsApp,
+    required this.onCall,
+    required this.onWhatsApp,
+  });
+
+  final bool canCall;
+  final bool canWhatsApp;
+  final VoidCallback onCall;
+  final VoidCallback onWhatsApp;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+      ),
+      decoration: const BoxDecoration(
+        color: AppColors.bottomNavBackground,
+        border: Border(top: BorderSide(color: AppColors.bottomNavTopBorder)),
+      ),
+      child: Row(
+        children: [
+          if (canCall)
+            Expanded(
+              child: SizedBox(
+                height: 52,
+                child: FilledButton.icon(
+                  onPressed: onCall,
+                  icon: const Icon(Icons.call_rounded),
+                  label: const Text(AppStrings.lostPetCall),
+                ),
+              ),
+            ),
+          if (canCall && canWhatsApp)
+            const SizedBox(width: AppDimensions.spaceM),
+          if (canWhatsApp)
+            Expanded(
+              child: SizedBox(
+                height: 52,
+                child: FilledButton.icon(
+                  onPressed: onWhatsApp,
+                  style: FilledButton.styleFrom(
+                    backgroundColor: const Color(0xFF25D366),
+                    foregroundColor: AppColors.onPrimary,
+                  ),
+                  icon: const Icon(Icons.chat_bubble_outline_rounded),
+                  label: const Text(AppStrings.lostPetWhatsApp),
+                ),
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/lost_pets/lost_pets_page.dart
+++ b/lib/presentation/pages/lost_pets/lost_pets_page.dart
@@ -1,0 +1,1050 @@
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+import '../../../app/routes.dart';
+import '../../../core/constants/app_colors.dart';
+import '../../../core/constants/app_dimensions.dart';
+import '../../../core/constants/app_strings.dart';
+import '../../../core/models/lost_pet_model.dart';
+import '../../../core/network/api_exception.dart';
+import '../../../core/services/app_image_cache_manager.dart';
+import '../../../core/services/lost_pet_service.dart';
+import '../../../shared/widgets/petcare_bottom_nav_bar.dart';
+
+class LostPetsPage extends StatefulWidget {
+  const LostPetsPage({super.key});
+
+  @override
+  State<LostPetsPage> createState() => _LostPetsPageState();
+}
+
+class _LostPetsPageState extends State<LostPetsPage> {
+  final LostPetService _lostPetService = LostPetService();
+  final TextEditingController _searchController = TextEditingController();
+
+  List<LostPetReportModel> _reports = const [];
+  _LostPetFilter _activeFilter = _LostPetFilter.all;
+  String _searchQuery = '';
+  bool _isLoading = false;
+  String? _errorMessage;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadLostPets();
+  }
+
+  @override
+  void dispose() {
+    _searchController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadLostPets({bool forceRefresh = false}) async {
+    setState(() {
+      _isLoading = true;
+      _errorMessage = null;
+    });
+
+    try {
+      final reports = await _lostPetService.getLostPets(
+        forceRefresh: forceRefresh,
+      );
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _reports = reports.where((report) => report.isActive).toList();
+      });
+    } on ApiException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _errorMessage = error.message;
+      });
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _errorMessage = AppStrings.lostPetsLoadError;
+      });
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  void _handleBottomNavTap(int index) {
+    final routeName = Routes.bottomNavRouteForIndex(index);
+    if (routeName == null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('This section is not available yet.')),
+      );
+      return;
+    }
+    Navigator.of(context).pushReplacementNamed(routeName);
+  }
+
+  void _openDetail(LostPetReportModel report) {
+    Navigator.of(context).pushNamed(Routes.lostPetDetail, arguments: report);
+  }
+
+  Future<void> _callOwner(LostPetReportModel report) async {
+    final phone = report.primaryContact?.phone.trim() ?? '';
+    if (phone.isEmpty) {
+      return;
+    }
+    await launchUrl(Uri(scheme: 'tel', path: phone));
+  }
+
+  List<LostPetReportModel> get _filteredReports {
+    final normalizedQuery = _normalizeSearch(_searchQuery);
+    return _reports
+        .where((report) {
+          final matchesFilter = switch (_activeFilter) {
+            _LostPetFilter.all => true,
+            _LostPetFilter.dogs => report.species.trim().toLowerCase() == 'dog',
+            _LostPetFilter.cats => report.species.trim().toLowerCase() == 'cat',
+          };
+          if (!matchesFilter) {
+            return false;
+          }
+          if (normalizedQuery.isEmpty) {
+            return true;
+          }
+          return _searchableText(report).contains(normalizedQuery);
+        })
+        .toList(growable: false);
+  }
+
+  String _searchableText(LostPetReportModel report) {
+    final contact = report.primaryContact;
+    return _normalizeSearch(
+      [
+        report.petName,
+        report.species,
+        report.breed,
+        report.color,
+        report.gender,
+        report.lastSeen.name,
+        report.lostNote,
+        contact?.name ?? '',
+        contact?.relationship ?? '',
+      ].join(' '),
+    );
+  }
+
+  String _normalizeSearch(String value) {
+    return value.trim().toLowerCase();
+  }
+
+  int _countFor(_LostPetFilter filter) {
+    return _reports.where((report) {
+      return switch (filter) {
+        _LostPetFilter.all => true,
+        _LostPetFilter.dogs => report.species.trim().toLowerCase() == 'dog',
+        _LostPetFilter.cats => report.species.trim().toLowerCase() == 'cat',
+      };
+    }).length;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: SafeArea(
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _Header(count: _reports.length),
+            Expanded(
+              child: RefreshIndicator(
+                onRefresh: () => _loadLostPets(forceRefresh: true),
+                child: _buildBody(),
+              ),
+            ),
+          ],
+        ),
+      ),
+      bottomNavigationBar: PetcareBottomNavBar(
+        currentIndex: 2,
+        onTap: _handleBottomNavTap,
+      ),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoading) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_errorMessage != null) {
+      return _ErrorState(message: _errorMessage!, onRetry: _loadLostPets);
+    }
+
+    final filteredReports = _filteredReports;
+
+    return ListView.separated(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.pageHorizontalPadding,
+        0,
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceXXL,
+      ),
+      itemCount: filteredReports.isEmpty ? 4 : filteredReports.length + 3,
+      separatorBuilder: (_, _) => const SizedBox(height: AppDimensions.spaceM),
+      itemBuilder: (context, index) {
+        if (index == 0) {
+          return const _HelpBanner();
+        }
+
+        if (index == 1) {
+          return _LostPetSearchBar(
+            controller: _searchController,
+            onChanged: (value) => setState(() => _searchQuery = value),
+            onClear: _searchQuery.isEmpty
+                ? null
+                : () {
+                    _searchController.clear();
+                    setState(() => _searchQuery = '');
+                  },
+          );
+        }
+
+        if (index == 2) {
+          return _LostPetFilters(
+            selected: _activeFilter,
+            allCount: _countFor(_LostPetFilter.all),
+            dogCount: _countFor(_LostPetFilter.dogs),
+            catCount: _countFor(_LostPetFilter.cats),
+            onSelected: (filter) => setState(() => _activeFilter = filter),
+          );
+        }
+
+        if (filteredReports.isEmpty) {
+          return _EmptyState(hasSearch: _searchQuery.trim().isNotEmpty);
+        }
+
+        final report = filteredReports[index - 3];
+        return _LostPetCard(
+          report: report,
+          onTap: () => _openDetail(report),
+          onCall: () => _callOwner(report),
+        );
+      },
+    );
+  }
+}
+
+enum _LostPetFilter { all, dogs, cats }
+
+class _Header extends StatelessWidget {
+  const _Header({required this.count});
+
+  final int count;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+        AppDimensions.pageHorizontalPadding,
+        AppDimensions.spaceM,
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Expanded(
+                child: Text(
+                  AppStrings.lostPetsTitle,
+                  style: Theme.of(context).textTheme.headlineMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppDimensions.spaceXS),
+          Text(
+            '$count pets need help',
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+              color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+              fontWeight: FontWeight.w400,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _HelpBanner extends StatelessWidget {
+  const _HelpBanner();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.negativeBackgroundDark.withValues(alpha: 0.45)
+            : AppColors.overdueCardBackground,
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(
+          color: isDark
+              ? AppColors.smartAlertWarningTextDark
+              : AppColors.overdueCardBorder,
+          width: 1.2,
+        ),
+      ),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Icon(
+            Icons.info_outline_rounded,
+            size: 20,
+            color: isDark
+                ? AppColors.smartAlertWarningTextDark
+                : AppColors.warning,
+          ),
+          const SizedBox(width: AppDimensions.spaceM),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  AppStrings.lostPetsHelpTitle,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: isDark
+                        ? AppColors.smartAlertWarningTextDark
+                        : AppColors.warning,
+                    fontWeight: FontWeight.w700,
+                    height: 1.2,
+                  ),
+                ),
+                const SizedBox(height: AppDimensions.spaceXS),
+                Text(
+                  AppStrings.lostPetsHelpBody,
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: isDark
+                        ? AppColors.onSurfaceDark
+                        : AppColors.onSecondary,
+                    fontWeight: FontWeight.w500,
+                    height: 1.35,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LostPetFilters extends StatelessWidget {
+  const _LostPetFilters({
+    required this.selected,
+    required this.allCount,
+    required this.dogCount,
+    required this.catCount,
+    required this.onSelected,
+  });
+
+  final _LostPetFilter selected;
+  final int allCount;
+  final int dogCount;
+  final int catCount;
+  final ValueChanged<_LostPetFilter> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _FilterChipButton(
+          label: 'All ($allCount)',
+          selected: selected == _LostPetFilter.all,
+          onTap: () => onSelected(_LostPetFilter.all),
+        ),
+        const SizedBox(width: AppDimensions.spaceS),
+        _FilterChipButton(
+          label: 'Dogs ($dogCount)',
+          selected: selected == _LostPetFilter.dogs,
+          onTap: () => onSelected(_LostPetFilter.dogs),
+        ),
+        const SizedBox(width: AppDimensions.spaceS),
+        _FilterChipButton(
+          label: 'Cats ($catCount)',
+          selected: selected == _LostPetFilter.cats,
+          onTap: () => onSelected(_LostPetFilter.cats),
+        ),
+      ],
+    );
+  }
+}
+
+class _LostPetSearchBar extends StatelessWidget {
+  const _LostPetSearchBar({
+    required this.controller,
+    required this.onChanged,
+    required this.onClear,
+  });
+
+  final TextEditingController controller;
+  final ValueChanged<String> onChanged;
+  final VoidCallback? onClear;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return TextField(
+      controller: controller,
+      onChanged: onChanged,
+      textInputAction: TextInputAction.search,
+      decoration: InputDecoration(
+        hintText: 'Search by name, breed, color or location',
+        prefixIcon: const Icon(Icons.search_rounded),
+        suffixIcon: onClear == null
+            ? null
+            : IconButton(
+                onPressed: onClear,
+                icon: const Icon(Icons.close_rounded),
+              ),
+        filled: true,
+        fillColor: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardBackground,
+        contentPadding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.spaceM,
+          vertical: AppDimensions.spaceM,
+        ),
+        border: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(
+            color: isDark ? AppColors.grey700 : AppColors.grey300,
+          ),
+        ),
+        enabledBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: BorderSide(
+            color: isDark ? AppColors.grey700 : AppColors.grey300,
+          ),
+        ),
+        focusedBorder: OutlineInputBorder(
+          borderRadius: BorderRadius.circular(14),
+          borderSide: const BorderSide(color: AppColors.primary, width: 1.4),
+        ),
+      ),
+    );
+  }
+}
+
+class _FilterChipButton extends StatelessWidget {
+  const _FilterChipButton({
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = selected
+        ? AppColors.primaryVariant
+        : (isDark
+              ? AppColors.petCardBackgroundDark
+              : AppColors.petCardBackground);
+    final textColor = selected
+        ? AppColors.primary
+        : (isDark ? AppColors.onSurfaceDark : AppColors.onSurface);
+
+    return Material(
+      color: backgroundColor,
+      borderRadius: BorderRadius.circular(22),
+      child: InkWell(
+        onTap: onTap,
+        borderRadius: BorderRadius.circular(22),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 12),
+          child: Text(
+            label,
+            style: Theme.of(context).textTheme.labelLarge?.copyWith(
+              color: textColor,
+              fontWeight: FontWeight.w600,
+              height: 1,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _LostPetCard extends StatelessWidget {
+  const _LostPetCard({
+    required this.report,
+    required this.onTap,
+    required this.onCall,
+  });
+
+  final LostPetReportModel report;
+  final VoidCallback onTap;
+  final VoidCallback onCall;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final surface = isDark
+        ? AppColors.petCardBackgroundDark
+        : AppColors.petCardBackground;
+
+    return Container(
+      decoration: BoxDecoration(
+        color: surface,
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.18 : 0.06),
+            blurRadius: 18,
+            offset: const Offset(0, 6),
+          ),
+        ],
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(28),
+        child: Material(
+          color: surface,
+          child: InkWell(
+            onTap: onTap,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                AspectRatio(
+                  aspectRatio: 16 / 9,
+                  child: Stack(
+                    fit: StackFit.expand,
+                    children: [
+                      _PetPhoto(photoUrl: report.photoUrl, isDark: isDark),
+                      Positioned(
+                        left: AppDimensions.spaceM,
+                        top: AppDimensions.spaceS,
+                        child: _LostBadge(isDark: isDark),
+                      ),
+                      Positioned(
+                        right: AppDimensions.spaceM,
+                        top: AppDimensions.spaceM,
+                        child: _SeenAgoBadge(report: report),
+                      ),
+                      Positioned(
+                        left: AppDimensions.spaceM,
+                        right: AppDimensions.spaceM,
+                        bottom: AppDimensions.spaceM,
+                        child: _PhotoTitle(report: report),
+                      ),
+                    ],
+                  ),
+                ),
+                Padding(
+                  padding: const EdgeInsets.fromLTRB(18, 18, 18, 14),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      _PetMetaRow(report: report, isDark: isDark),
+                      const SizedBox(height: AppDimensions.spaceM),
+                      _LocationRow(location: report.lastSeen, isDark: isDark),
+                      const SizedBox(height: AppDimensions.spaceM),
+                      Divider(
+                        color: isDark
+                            ? AppColors.bottomNavTopBorderDark
+                            : AppColors.bottomNavTopBorder,
+                        height: 1,
+                      ),
+                      const SizedBox(height: AppDimensions.spaceM),
+                      _OwnerCallRow(
+                        contact: report.primaryContact,
+                        isDark: isDark,
+                        onCall: onCall,
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _PhotoTitle extends StatelessWidget {
+  const _PhotoTitle({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          report.petName,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.headlineSmall?.copyWith(
+            color: AppColors.onPrimary,
+            fontWeight: FontWeight.w700,
+            height: 1.05,
+            shadows: const [Shadow(color: Colors.black54, blurRadius: 8)],
+          ),
+        ),
+        const SizedBox(height: AppDimensions.spaceXS),
+        Text(
+          report.breed.trim().isEmpty ? report.species : report.breed,
+          maxLines: 1,
+          overflow: TextOverflow.ellipsis,
+          style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+            color: AppColors.onPrimary.withValues(alpha: 0.92),
+            fontWeight: FontWeight.w500,
+            shadows: const [Shadow(color: Colors.black54, blurRadius: 8)],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _SeenAgoBadge extends StatelessWidget {
+  const _SeenAgoBadge({required this.report});
+
+  final LostPetReportModel report;
+
+  @override
+  Widget build(BuildContext context) {
+    final seenAt =
+        report.createdAt ?? report.updatedAt ?? report.lastSeen.seenAt;
+    if (seenAt == null) {
+      return const SizedBox.shrink();
+    }
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: Colors.black.withValues(alpha: 0.42),
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.access_time_rounded,
+              size: 13,
+              color: AppColors.onPrimary,
+            ),
+            const SizedBox(width: 4),
+            Text(
+              _formatAgo(seenAt),
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: AppColors.onPrimary,
+                fontWeight: FontWeight.w600,
+                height: 1,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatAgo(DateTime date) {
+    final difference = DateTime.now().difference(date);
+    if (difference.inDays >= 1) {
+      return '${difference.inDays} day${difference.inDays == 1 ? '' : 's'} ago';
+    }
+    if (difference.inHours >= 1) {
+      return '${difference.inHours} hr ago';
+    }
+    final minutes = difference.inMinutes.clamp(1, 59);
+    return '$minutes min ago';
+  }
+}
+
+class _PetMetaRow extends StatelessWidget {
+  const _PetMetaRow({required this.report, required this.isDark});
+
+  final LostPetReportModel report;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        _SpeciesBadge(species: report.species, isDark: isDark),
+        const SizedBox(width: AppDimensions.spaceS),
+        Expanded(
+          child: Text(
+            _metaText(report),
+            maxLines: 1,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+              color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+              fontWeight: FontWeight.w500,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _metaText(LostPetReportModel report) {
+    final parts = [
+      if (report.gender.trim().isNotEmpty) report.gender.trim(),
+      if (report.ageLabel.trim().isNotEmpty) report.ageLabel.trim(),
+      if (report.weight != null) '${report.weight!.toStringAsFixed(1)} kg',
+    ].where((part) => part.isNotEmpty).toList();
+    return parts.join(' · ');
+  }
+}
+
+class _SpeciesBadge extends StatelessWidget {
+  const _SpeciesBadge({required this.species, required this.isDark});
+
+  final String species;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final label = species.trim().isEmpty ? 'Pet' : species.trim();
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 7),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.quickActionIconBackgroundDark
+            : AppColors.primaryVariant,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        label,
+        style: Theme.of(context).textTheme.bodySmall?.copyWith(
+          color: isDark ? AppColors.quickActionIconTintDark : AppColors.primary,
+          fontWeight: FontWeight.w600,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _PetPhoto extends StatelessWidget {
+  const _PetPhoto({required this.photoUrl, required this.isDark});
+
+  final String? photoUrl;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final url = photoUrl?.trim();
+    if (url == null || url.isEmpty) {
+      return _PetPhotoPlaceholder(isDark: isDark);
+    }
+
+    return CachedNetworkImage(
+      imageUrl: url,
+      cacheManager: AppImageCacheManager.instance,
+      fit: BoxFit.cover,
+      placeholder: (_, _) => _PetPhotoPlaceholder(isDark: isDark),
+      errorWidget: (_, _, _) => _PetPhotoPlaceholder(isDark: isDark),
+    );
+  }
+}
+
+class _PetPhotoPlaceholder extends StatelessWidget {
+  const _PetPhotoPlaceholder({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: isDark
+          ? AppColors.petCardQuickActionBgDark
+          : AppColors.petCardQuickActionBg,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.pets_rounded,
+        size: AppDimensions.iconXL,
+        color: isDark
+            ? AppColors.quickActionIconTintDark
+            : AppColors.quickActionIconTint,
+      ),
+    );
+  }
+}
+
+class _LostBadge extends StatelessWidget {
+  const _LostBadge({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 6),
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.negativeBackgroundDark : AppColors.onPrimary,
+        borderRadius: BorderRadius.circular(999),
+      ),
+      child: Text(
+        AppStrings.petDetailStatusLost,
+        style: TextStyle(
+          color: isDark ? AppColors.negativeTextDark : AppColors.negativeText,
+          fontSize: 12,
+          fontWeight: FontWeight.w600,
+          height: 1,
+        ),
+      ),
+    );
+  }
+}
+
+class _OwnerCallRow extends StatelessWidget {
+  const _OwnerCallRow({
+    required this.contact,
+    required this.isDark,
+    required this.onCall,
+  });
+
+  final LostPetContactModel? contact;
+  final bool isDark;
+  final VoidCallback onCall;
+
+  @override
+  Widget build(BuildContext context) {
+    final name = contact?.name.trim().isNotEmpty == true
+        ? contact!.name.trim()
+        : 'Owner';
+    final relationship = contact?.relationship.trim().isNotEmpty == true
+        ? contact!.relationship.trim()
+        : 'Owner';
+    final canCall =
+        contact?.allowCall == true && contact!.phone.trim().isNotEmpty;
+
+    return Row(
+      children: [
+        CircleAvatar(
+          radius: 18,
+          backgroundColor: isDark
+              ? AppColors.quickActionIconBackgroundDark
+              : AppColors.primaryVariant,
+          foregroundColor: isDark
+              ? AppColors.quickActionIconTintDark
+              : AppColors.primary,
+          child: Text(
+            _initials(name),
+            style: const TextStyle(fontSize: 12, fontWeight: FontWeight.w700),
+          ),
+        ),
+        const SizedBox(width: AppDimensions.spaceM),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                name,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: isDark ? AppColors.onSurfaceDark : AppColors.grey900,
+                  fontWeight: FontWeight.w700,
+                  height: 1.15,
+                ),
+              ),
+              const SizedBox(height: 2),
+              Text(
+                relationship,
+                maxLines: 1,
+                overflow: TextOverflow.ellipsis,
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+                  fontWeight: FontWeight.w500,
+                  height: 1.1,
+                ),
+              ),
+            ],
+          ),
+        ),
+        const SizedBox(width: AppDimensions.spaceS),
+        SizedBox(
+          height: 44,
+          child: FilledButton.icon(
+            onPressed: canCall ? onCall : null,
+            icon: const Icon(Icons.call_rounded, size: 16),
+            label: const Text(AppStrings.lostPetCall),
+            style: FilledButton.styleFrom(
+              backgroundColor: AppColors.primary,
+              foregroundColor: AppColors.onPrimary,
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(22),
+              ),
+              textStyle: const TextStyle(
+                fontSize: 13,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  String _initials(String value) {
+    final parts = value
+        .trim()
+        .split(RegExp(r'\s+'))
+        .where((part) => part.isNotEmpty)
+        .toList();
+    if (parts.isEmpty) {
+      return '?';
+    }
+    return parts.take(2).map((part) => part[0].toUpperCase()).join();
+  }
+}
+
+class _LocationRow extends StatelessWidget {
+  const _LocationRow({required this.location, required this.isDark});
+
+  final LostPetLocationModel location;
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    final text = location.name.trim().isNotEmpty
+        ? location.name.trim()
+        : 'Bogotá';
+    return Container(
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppDimensions.spaceM,
+        vertical: AppDimensions.spaceS,
+      ),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardQuickActionBgDark
+            : AppColors.petCardQuickActionBg,
+        borderRadius: BorderRadius.circular(18),
+      ),
+      child: Row(
+        children: [
+          Icon(
+            Icons.location_on_outlined,
+            size: 18,
+            color: isDark
+                ? AppColors.quickActionIconTintDark
+                : AppColors.bottomNavActive,
+          ),
+          const SizedBox(width: AppDimensions.spaceS),
+          Expanded(
+            child: Text(
+              '${AppStrings.lostPetLastSeen}: $text',
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                color: isDark ? AppColors.onSurfaceDark : AppColors.onSurface,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.hasSearch});
+
+  final bool hasSearch;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppDimensions.spaceXL),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.location_off_rounded,
+              size: 56,
+              color: AppColors.grey300,
+            ),
+            const SizedBox(height: AppDimensions.spaceM),
+            Text(
+              hasSearch
+                  ? 'No lost pets match that search.'
+                  : AppStrings.lostPetsEmpty,
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(color: AppColors.grey500),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ErrorState extends StatelessWidget {
+  const _ErrorState({required this.message, required this.onRetry});
+
+  final String message;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppDimensions.spaceXL),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Icon(
+              Icons.cloud_off_rounded,
+              size: 56,
+              color: AppColors.grey300,
+            ),
+            const SizedBox(height: AppDimensions.spaceM),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(
+                context,
+              ).textTheme.titleMedium?.copyWith(color: AppColors.grey500),
+            ),
+            const SizedBox(height: AppDimensions.spaceM),
+            ElevatedButton(
+              onPressed: onRetry,
+              child: const Text(AppStrings.lostPetsRetry),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/pages/nfc/nfc_page.dart
+++ b/lib/presentation/pages/nfc/nfc_page.dart
@@ -9,6 +9,8 @@ import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_dimensions.dart';
 import '../../../core/constants/app_strings.dart';
 import '../../../core/network/api_exception.dart';
+import '../../../core/services/location_service.dart';
+import '../../../core/services/lost_pet_service.dart';
 import '../../../core/services/nfc_backend_service.dart';
 import '../../../core/services/nfc_service.dart';
 import '../../../core/services/pet_service.dart';
@@ -39,6 +41,8 @@ class _NfcPageState extends State<NfcPage> {
 
   final NfcService _nfcService = NfcService();
   final NfcBackendService _nfcBackendService = NfcBackendService();
+  final LostPetService _lostPetService = LostPetService();
+  final LocationService _locationService = LocationService();
   final PetService _petService = PetService();
   final UserService _userService = UserService();
   final TelemetryService _telemetryService = TelemetryService();
@@ -217,9 +221,13 @@ class _NfcPageState extends State<NfcPage> {
           rawPayload: payload,
           payload: parsedPayload,
         );
-        final resolvedReadPayload = _resolveOfflineReadPayload(
+        final offlineReadPayload = _resolveOfflineReadPayload(
           rawPayload: payload,
           parsedPayload: parsedPayload,
+          scannedPetId: scannedPetId,
+        );
+        final resolvedReadPayload = await _enrichReadPayload(
+          offlinePayload: offlineReadPayload,
           scannedPetId: scannedPetId,
         );
 
@@ -237,6 +245,7 @@ class _NfcPageState extends State<NfcPage> {
           _viewState = _NfcViewState.success;
         });
         _logNfcReadIfPossible();
+        unawaited(_openLostPetDetailIfNeeded(resolvedReadPayload));
         return;
       }
 
@@ -333,6 +342,206 @@ class _NfcPageState extends State<NfcPage> {
     }
 
     return <String, dynamic>{'rawText': trimmedPayload};
+  }
+
+  Future<Map<String, dynamic>?> _enrichReadPayload({
+    required Map<String, dynamic>? offlinePayload,
+    required String? scannedPetId,
+  }) async {
+    final petId = scannedPetId?.trim();
+    if (petId == null || petId.isEmpty) {
+      return offlinePayload;
+    }
+
+    try {
+      if (offlinePayload != null &&
+          _isOwnedPet(petId) &&
+          _hasActiveLostReport(offlinePayload)) {
+        return _markOwnedLostPetFoundFromScan(
+          petId: petId,
+          offlinePayload: offlinePayload,
+        );
+      }
+
+      final publicPayload = await _nfcBackendService.readPublicTagData(petId);
+      if (_isOwnedPet(petId) && _hasActiveLostReport(publicPayload)) {
+        return _markOwnedLostPetFoundFromScan(
+          petId: petId,
+          offlinePayload: <String, dynamic>{
+            ...?offlinePayload,
+            ...publicPayload,
+          },
+        );
+      }
+
+      final sightingPayload = await _recordNfcSightingIfLost(
+        petId: petId,
+        publicPayload: publicPayload,
+      );
+      return <String, dynamic>{
+        ...?offlinePayload,
+        ...publicPayload,
+        ...sightingPayload,
+      };
+    } catch (_) {
+      return offlinePayload;
+    }
+  }
+
+  Future<Map<String, dynamic>> _markOwnedLostPetFoundFromScan({
+    required String petId,
+    required Map<String, dynamic>? offlinePayload,
+  }) async {
+    await _lostPetService.markPetAsFound(petId);
+    unawaited(_loadPets());
+    if (mounted) {
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.lostModeFound)));
+    }
+    return <String, dynamic>{
+      ...?offlinePayload,
+      'status': 'healthy',
+      'activeLostReportId': '',
+      'lostReportUrl': '',
+    };
+  }
+
+  bool _isOwnedPet(String petId) {
+    return _pets.any((pet) => pet.id == petId);
+  }
+
+  bool _hasActiveLostReport(Map<String, dynamic> payload) {
+    final reportId = _readPayloadOptionalText(payload, const [
+      'activeLostReportId',
+      'active_lost_report_id',
+      'lostReportId',
+    ]);
+    return reportId != null && reportId.isNotEmpty;
+  }
+
+  Future<void> _openLostPetDetailIfNeeded(Map<String, dynamic>? payload) async {
+    final reportId = _readPayloadOptionalText(payload, const [
+      'activeLostReportId',
+      'active_lost_report_id',
+      'lostReportId',
+    ]);
+    if (reportId == null || reportId.isEmpty) {
+      return;
+    }
+
+    try {
+      final report = await _lostPetService.getLostPetDetail(reportId);
+      if (!mounted) {
+        return;
+      }
+      await Navigator.of(
+        context,
+      ).pushNamed(Routes.lostPetDetail, arguments: report);
+    } catch (_) {
+      // Keep the NFC success screen available if the detail fetch fails.
+    }
+  }
+
+  Future<Map<String, dynamic>> _recordNfcSightingIfLost({
+    required String petId,
+    required Map<String, dynamic> publicPayload,
+  }) async {
+    final reportId = _readPayloadOptionalText(publicPayload, const [
+      'activeLostReportId',
+      'active_lost_report_id',
+      'lostReportId',
+    ]);
+    if (reportId == null || reportId.isEmpty || !mounted) {
+      return const <String, dynamic>{};
+    }
+
+    final shareContact = await showDialog<bool>(
+      context: context,
+      builder: (dialogContext) {
+        return AlertDialog(
+          title: const Text('Share this NFC scan?'),
+          content: const Text(
+            'This pet is marked as lost. You can share the current location with the owner, and optionally your contact profile.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(dialogContext).pop(false),
+              child: const Text('Location only'),
+            ),
+            FilledButton(
+              onPressed: () => Navigator.of(dialogContext).pop(true),
+              child: const Text('Share contact'),
+            ),
+          ],
+        );
+      },
+    );
+
+    if (shareContact == null) {
+      return const <String, dynamic>{};
+    }
+
+    try {
+      final payload = await _buildNfcScanContext(includeContact: shareContact);
+      final response = await _nfcBackendService.recordNfcLostPetSighting(
+        petId: petId,
+        data: payload,
+      );
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('The owner was notified.')),
+        );
+      }
+      return response;
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text(AppStrings.lostPetLocationUnavailable)),
+        );
+      }
+      return const <String, dynamic>{};
+    }
+  }
+
+  Future<Map<String, dynamic>> _buildNfcScanContext({
+    required bool includeContact,
+  }) async {
+    final context = <String, dynamic>{
+      'scanSource': 'nfc',
+      'seenAt': DateTime.now().toIso8601String(),
+    };
+
+    final location = await _locationService.getCurrentLocation();
+    context['latitude'] = location.latitude;
+    context['longitude'] = location.longitude;
+    context['location'] = _nearestBogotaZone(
+      latitude: location.latitude,
+      longitude: location.longitude,
+    );
+
+    if (!includeContact) {
+      return context;
+    }
+    try {
+      final profile = await _userService.getCurrentUser();
+      final name = profile.name.trim();
+      final phone = profile.phone.trim();
+      final email = profile.email.trim();
+      if (name.isNotEmpty) {
+        context['reporterName'] = name;
+      }
+      if (phone.isNotEmpty) {
+        context['reporterPhone'] = phone;
+      }
+      if (email.isNotEmpty) {
+        context['reporterEmail'] = email;
+      }
+    } catch (_) {
+      // Reporter profile is optional for public NFC reads.
+    }
+
+    return context;
   }
 
   Future<void> _simulateWriteWithoutNfc() async {
@@ -498,6 +707,39 @@ class _NfcPageState extends State<NfcPage> {
     }
 
     return normalized;
+  }
+
+  String _nearestBogotaZone({
+    required double latitude,
+    required double longitude,
+  }) {
+    const zones = <({String name, double latitude, double longitude})>[
+      (name: 'Usaquén, Bogotá', latitude: 4.7038, longitude: -74.0309),
+      (name: 'Chicó Norte, Bogotá', latitude: 4.6787, longitude: -74.0488),
+      (name: 'Santa Bárbara, Bogotá', latitude: 4.6995, longitude: -74.0443),
+      (name: 'Cedritos, Bogotá', latitude: 4.7284, longitude: -74.0448),
+      (name: 'Parque El Virrey, Bogotá', latitude: 4.6741, longitude: -74.0539),
+      (name: 'Colina Campestre, Bogotá', latitude: 4.7416, longitude: -74.0661),
+      (name: 'Country Club, Bogotá', latitude: 4.7244, longitude: -74.0511),
+      (name: 'La Castellana, Bogotá', latitude: 4.6868, longitude: -74.0648),
+    ];
+
+    var nearest = zones.first;
+    var nearestDistance =
+        ((nearest.latitude - latitude) * (nearest.latitude - latitude)) +
+        ((nearest.longitude - longitude) * (nearest.longitude - longitude));
+
+    for (final zone in zones.skip(1)) {
+      final distance =
+          ((zone.latitude - latitude) * (zone.latitude - latitude)) +
+          ((zone.longitude - longitude) * (zone.longitude - longitude));
+      if (distance < nearestDistance) {
+        nearest = zone;
+        nearestDistance = distance;
+      }
+    }
+
+    return 'Near ${nearest.name}';
   }
 
   Map<String, dynamic> _applyWriteOptions({
@@ -729,7 +971,8 @@ class _NfcPageState extends State<NfcPage> {
     final pet = _selectedPet;
     final selectedPetName = pet?.name ?? 'your pet';
     final canWriteTag = pet != null;
-    final canStartNfc = isReadMode || canWriteTag;
+    final canReadTag = !_isLoadingPets && _petsLoadErrorMessage == null;
+    final canStartNfc = isReadMode ? canReadTag : canWriteTag;
     final isSimulationMode = _isNfcAvailable == false;
     final actionButtonText = isSimulationMode
         ? (isReadMode ? 'Test Read (Simulation)' : 'Test Write (Simulation)')
@@ -754,6 +997,20 @@ class _NfcPageState extends State<NfcPage> {
         if (_operationErrorMessage != null) ...[
           const SizedBox(height: AppDimensions.spaceM),
           NfcStatusBanner(message: _operationErrorMessage!, isAttention: true),
+        ],
+        if (isReadMode && _isLoadingPets) ...[
+          const SizedBox(height: AppDimensions.spaceM),
+          const Center(child: CircularProgressIndicator()),
+        ] else if (isReadMode && _petsLoadErrorMessage != null) ...[
+          const SizedBox(height: AppDimensions.spaceM),
+          NfcStatusBanner(message: _petsLoadErrorMessage!, isAttention: true),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton(
+              onPressed: _loadPets,
+              child: const Text(AppStrings.petsRetry),
+            ),
+          ),
         ],
         const SizedBox(height: AppDimensions.spaceXXL),
         if (!isReadMode) ...[
@@ -1561,61 +1818,65 @@ class _NfcPageState extends State<NfcPage> {
                     ),
                   ],
                 ),
-                const SizedBox(height: AppDimensions.spaceM),
-                Container(
-                  width: double.infinity,
-                  padding: const EdgeInsets.all(AppDimensions.spaceM),
-                  decoration: BoxDecoration(
-                    color: isDark
-                        ? AppColors.negativeBackgroundDark
-                        : AppColors.petStatusAttentionBg,
-                    borderRadius: BorderRadius.circular(AppDimensions.radiusL),
-                    border: Border.all(
+                if (medicalNotesValue.isNotEmpty) ...[
+                  const SizedBox(height: AppDimensions.spaceM),
+                  Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(AppDimensions.spaceM),
+                    decoration: BoxDecoration(
                       color: isDark
-                          ? AppColors.negativeTextDark
-                          : AppColors.warning,
-                      width: AppDimensions.strokeRegular,
+                          ? AppColors.negativeBackgroundDark
+                          : AppColors.petStatusAttentionBg,
+                      borderRadius: BorderRadius.circular(
+                        AppDimensions.radiusL,
+                      ),
+                      border: Border.all(
+                        color: isDark
+                            ? AppColors.negativeTextDark
+                            : AppColors.warning,
+                        width: AppDimensions.strokeRegular,
+                      ),
                     ),
-                  ),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Row(
-                        children: [
-                          Icon(
-                            Icons.warning_amber_rounded,
-                            color: isDark
-                                ? AppColors.negativeTextDark
-                                : AppColors.warning,
-                            size: AppDimensions.iconS,
-                          ),
-                          SizedBox(width: AppDimensions.spaceXXS),
-                          Text(
-                            AppStrings.nfcMedicalNotes,
-                            style: TextStyle(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Row(
+                          children: [
+                            Icon(
+                              Icons.warning_amber_rounded,
                               color: isDark
                                   ? AppColors.negativeTextDark
                                   : AppColors.warning,
-                              fontSize: 14,
-                              fontWeight: FontWeight.w700,
+                              size: AppDimensions.iconS,
                             ),
-                          ),
-                        ],
-                      ),
-                      const SizedBox(height: AppDimensions.spaceXS),
-                      Text(
-                        medicalNotesValue,
-                        style: TextStyle(
-                          color: isDark
-                              ? AppColors.onSurfaceDark
-                              : AppColors.warning,
-                          fontSize: 14,
-                          fontWeight: FontWeight.w500,
+                            SizedBox(width: AppDimensions.spaceXXS),
+                            Text(
+                              AppStrings.nfcMedicalNotes,
+                              style: TextStyle(
+                                color: isDark
+                                    ? AppColors.negativeTextDark
+                                    : AppColors.warning,
+                                fontSize: 14,
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                          ],
                         ),
-                      ),
-                    ],
+                        const SizedBox(height: AppDimensions.spaceXS),
+                        Text(
+                          medicalNotesValue,
+                          style: TextStyle(
+                            color: isDark
+                                ? AppColors.onSurfaceDark
+                                : AppColors.warning,
+                            fontSize: 14,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                      ],
+                    ),
                   ),
-                ),
+                ],
               ],
             ),
           ),
@@ -1686,7 +1947,7 @@ class _NfcPageState extends State<NfcPage> {
 
   String _buildMedicalNotes(Map<String, dynamic>? payload) {
     if (payload == null) {
-      return AppStrings.nfcMedicalNotesValue;
+      return '';
     }
 
     final parts = <String>[];
@@ -1721,7 +1982,7 @@ class _NfcPageState extends State<NfcPage> {
     }
 
     if (parts.isEmpty) {
-      return AppStrings.nfcMedicalNotesValue;
+      return '';
     }
 
     return parts.join('. ');

--- a/lib/presentation/pages/pets/lost_mode/lost_mode_form_page.dart
+++ b/lib/presentation/pages/pets/lost_mode/lost_mode_form_page.dart
@@ -1,0 +1,1028 @@
+import 'dart:io';
+
+import 'package:cached_network_image/cached_network_image.dart';
+import 'package:flutter/material.dart';
+
+import '../../../../app/routes.dart';
+import '../../../../core/constants/app_colors.dart';
+import '../../../../core/constants/app_dimensions.dart';
+import '../../../../core/constants/app_strings.dart';
+import '../../../../core/forms/app_form_utils.dart';
+import '../../../../core/models/lost_pet_model.dart';
+import '../../../../core/models/user_profile.dart';
+import '../../../../core/network/api_exception.dart';
+import '../../../../core/services/app_image_cache_manager.dart';
+import '../../../../core/services/location_service.dart';
+import '../../../../core/services/lost_pet_service.dart';
+import '../../../../core/services/user_service.dart';
+import '../../../../shared/widgets/lost_pet_map_preview.dart';
+import '../../../../shared/widgets/petcare_bottom_nav_bar.dart';
+import '../models/pet_ui_model.dart';
+
+class LostModeFormPage extends StatefulWidget {
+  const LostModeFormPage({super.key, required this.pet});
+
+  final PetUiModel pet;
+
+  @override
+  State<LostModeFormPage> createState() => _LostModeFormPageState();
+}
+
+class _LostModeFormPageState extends State<LostModeFormPage> {
+  final _formKey = GlobalKey<FormState>();
+  final LostPetService _lostPetService = LostPetService();
+  final LocationService _locationService = LocationService();
+  final UserService _userService = UserService();
+
+  final _noteController = TextEditingController();
+  final _locationNameController = TextEditingController();
+  final _latitudeController = TextEditingController();
+  final _longitudeController = TextEditingController();
+  final _contactNameController = TextEditingController();
+  final _contactPhoneController = TextEditingController();
+
+  LostPetReportModel? _existingReport;
+  bool _isLoading = false;
+  bool _isSaving = false;
+  bool _isResolving = false;
+  bool _nfcNotificationsEnabled = true;
+  bool _allowCall = false;
+  bool _allowWhatsApp = false;
+  bool _exposeMedicalInfo = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadInitialData();
+  }
+
+  @override
+  void dispose() {
+    _noteController.dispose();
+    _locationNameController.dispose();
+    _latitudeController.dispose();
+    _longitudeController.dispose();
+    _contactNameController.dispose();
+    _contactPhoneController.dispose();
+    super.dispose();
+  }
+
+  Future<void> _loadInitialData() async {
+    setState(() {
+      _isLoading = true;
+    });
+
+    try {
+      final results = await Future.wait<dynamic>([
+        _lostPetService.getOwnerLostReport(widget.pet.id),
+        _userService.getCurrentUser(),
+      ]);
+      final report = results[0] as LostPetReportModel?;
+      final user = results[1] as UserProfile;
+
+      if (!mounted) {
+        return;
+      }
+
+      final activeReport = report?.isActive == true ? report : null;
+      _existingReport = activeReport;
+      if (activeReport != null) {
+        _noteController.text = activeReport.lostNote;
+        _locationNameController.text = activeReport.lastSeen.name;
+        _latitudeController.text =
+            activeReport.lastSeen.latitude?.toStringAsFixed(6) ?? '';
+        _longitudeController.text =
+            activeReport.lastSeen.longitude?.toStringAsFixed(6) ?? '';
+        final primaryContact = activeReport.primaryContact;
+        _contactNameController.text = primaryContact?.name ?? user.name;
+        _contactPhoneController.text = primaryContact?.phone ?? user.phone;
+        _allowCall = primaryContact?.allowCall ?? true;
+        _allowWhatsApp = primaryContact?.allowWhatsApp ?? true;
+        _exposeMedicalInfo = activeReport.exposeMedicalInfo;
+        _nfcNotificationsEnabled = activeReport.nfcNotificationsEnabled;
+      } else {
+        _contactNameController.text = user.name;
+        _contactPhoneController.text = user.phone;
+      }
+    } catch (_) {
+      // The form can still be filled manually.
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _useCurrentLocation() async {
+    try {
+      final location = await _locationService.getCurrentLocation();
+      if (!mounted) {
+        return;
+      }
+      setState(() {
+        _latitudeController.text = location.latitude.toStringAsFixed(6);
+        _longitudeController.text = location.longitude.toStringAsFixed(6);
+        _locationNameController.text = 'Current phone location';
+      });
+    } on LocationServiceException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text(AppStrings.lostPetLocationUnavailable)),
+      );
+    }
+  }
+
+  Future<void> _saveLostMode() async {
+    AppFormSanitizers.trimControllers([
+      _noteController,
+      _locationNameController,
+      _latitudeController,
+      _longitudeController,
+      _contactNameController,
+      _contactPhoneController,
+    ]);
+
+    if (!(_formKey.currentState?.validate() ?? false)) {
+      return;
+    }
+
+    setState(() {
+      _isSaving = true;
+    });
+
+    final payload = {
+      'city': 'Bogotá',
+      'lostNote': _noteController.text.trim(),
+      'lastSeenLocation': _lastSeenLocationLabel(),
+      'lastSeenLatitude': double.tryParse(_latitudeController.text.trim()),
+      'lastSeenLongitude': double.tryParse(_longitudeController.text.trim()),
+      'lastSeenAt': DateTime.now().toIso8601String(),
+      'exposeMedicalInfo': _exposeMedicalInfo,
+      'nfcNotificationsEnabled': _nfcNotificationsEnabled,
+      'emergencyContacts': [
+        {
+          'name': _contactNameController.text.trim(),
+          'phone': _contactPhoneController.text.trim(),
+          'whatsapp': _contactPhoneController.text.trim(),
+          'relationship': 'Owner',
+          'preferred': true,
+          'exposePhone': _allowCall,
+          'exposeWhatsapp': _allowWhatsApp,
+        },
+      ],
+      'petName': widget.pet.name,
+      'species': widget.pet.species,
+      'breed': widget.pet.breed,
+      'gender': widget.pet.gender,
+      'color': widget.pet.color,
+      'weight': widget.pet.weight,
+      'photoUrl': widget.pet.photoUrl,
+      'knownAllergies': widget.pet.knownAllergies,
+      'defaultVet': widget.pet.defaultVet,
+      'defaultClinic': widget.pet.defaultClinic,
+    };
+
+    try {
+      await _lostPetService.saveOwnerLostReport(
+        petId: widget.pet.id,
+        data: payload,
+        isUpdate: _existingReport != null,
+      );
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.lostModeSaved)));
+      Navigator.of(context).pop(true);
+    } on ApiException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isSaving = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _markFound() async {
+    setState(() {
+      _isResolving = true;
+    });
+
+    try {
+      await _lostPetService.markPetAsFound(widget.pet.id);
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.lostModeFound)));
+      Navigator.of(context).pop(true);
+    } on ApiException catch (error) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(SnackBar(content: Text(error.message)));
+    } catch (_) {
+      if (!mounted) {
+        return;
+      }
+      ScaffoldMessenger.of(
+        context,
+      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
+    } finally {
+      if (mounted) {
+        setState(() {
+          _isResolving = false;
+        });
+      }
+    }
+  }
+
+  String? _requiredValidator(String? value) {
+    final trimmed = value?.trim() ?? '';
+    return trimmed.isEmpty ? 'Required field.' : null;
+  }
+
+  String? _phoneValidator(String? value) {
+    final trimmed = value?.trim() ?? '';
+    if (trimmed.isEmpty) {
+      return 'Required field.';
+    }
+    return AppFormValidators.phone(
+      maxLength: 20,
+      invalidMessage: 'Invalid phone number.',
+    ).call(value);
+  }
+
+  String? _latitudeValidator(String? value) {
+    final trimmed = value?.trim() ?? '';
+    final longitude = _longitudeController.text.trim();
+    if (trimmed.isEmpty && longitude.isEmpty) {
+      return null;
+    }
+    if (trimmed.isEmpty) {
+      return 'Latitude required.';
+    }
+    final latitude = double.tryParse(trimmed);
+    if (latitude == null || latitude < -90 || latitude > 90) {
+      return 'Invalid latitude.';
+    }
+    return null;
+  }
+
+  String? _longitudeValidator(String? value) {
+    final trimmed = value?.trim() ?? '';
+    final latitude = _latitudeController.text.trim();
+    if (trimmed.isEmpty && latitude.isEmpty) {
+      return null;
+    }
+    if (trimmed.isEmpty) {
+      return 'Longitude required.';
+    }
+    final longitude = double.tryParse(trimmed);
+    if (longitude == null || longitude < -180 || longitude > 180) {
+      return 'Invalid longitude.';
+    }
+    return null;
+  }
+
+  void _setMapPoint(LostPetMapPoint point) {
+    setState(() {
+      _latitudeController.text = point.latitude.toStringAsFixed(6);
+      _longitudeController.text = point.longitude.toStringAsFixed(6);
+      _locationNameController.text = 'Selected map point';
+    });
+  }
+
+  double? _readCoordinate(TextEditingController controller) {
+    return double.tryParse(controller.text.trim());
+  }
+
+  String _lastSeenLocationLabel() {
+    final existingLabel = _locationNameController.text.trim();
+    if (existingLabel.isNotEmpty) {
+      return existingLabel;
+    }
+    if (_readCoordinate(_latitudeController) != null &&
+        _readCoordinate(_longitudeController) != null) {
+      return 'Selected map point';
+    }
+    return '';
+  }
+
+  void _handleBottomNavTap(int index) {
+    final routeName = Routes.bottomNavRouteForIndex(index);
+    if (routeName == null) {
+      return;
+    }
+    Navigator.of(context).pushReplacementNamed(routeName);
+  }
+
+  void _showExtraContactsComingSoon() {
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Additional contacts are coming soon.')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final hasActiveLostReport = _existingReport?.isActive == true;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppStrings.lostModeTitle),
+        actions: [
+          IconButton(
+            onPressed: _isSaving ? null : _saveLostMode,
+            icon: _isSaving
+                ? const SizedBox(
+                    width: 18,
+                    height: 18,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  )
+                : const Icon(Icons.check_rounded),
+          ),
+        ],
+      ),
+      body: SafeArea(
+        child: _isLoading
+            ? const Center(child: CircularProgressIndicator())
+            : Form(
+                key: _formKey,
+                autovalidateMode: AutovalidateMode.onUserInteraction,
+                child: ListView(
+                  padding: const EdgeInsets.fromLTRB(
+                    AppDimensions.pageHorizontalPadding,
+                    AppDimensions.spaceM,
+                    AppDimensions.pageHorizontalPadding,
+                    AppDimensions.spaceXXXL,
+                  ),
+                  children: [
+                    _PetHero(pet: widget.pet),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    _LostStatusCard(
+                      hasActiveLostReport: hasActiveLostReport,
+                      isResolving: _isResolving,
+                      onMarkFound: _markFound,
+                    ),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    _LostSettingsCard(
+                      enabled: _nfcNotificationsEnabled,
+                      exposeMedicalInfo: _exposeMedicalInfo,
+                      hasMedicalInfo: widget.pet.knownAllergies
+                          .trim()
+                          .isNotEmpty,
+                      onChanged: (value) {
+                        setState(() => _nfcNotificationsEnabled = value);
+                      },
+                      onExposeMedicalInfoChanged: (value) {
+                        setState(() => _exposeMedicalInfo = value);
+                      },
+                    ),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    _EmergencyContactCard(
+                      contactNameController: _contactNameController,
+                      contactPhoneController: _contactPhoneController,
+                      phoneValidator: _phoneValidator,
+                      nameValidator: _requiredValidator,
+                      onAddTap: _showExtraContactsComingSoon,
+                      allowCall: _allowCall,
+                      allowWhatsApp: _allowWhatsApp,
+                      onAllowCallChanged: (value) {
+                        setState(() => _allowCall = value);
+                      },
+                      onAllowWhatsAppChanged: (value) {
+                        setState(() => _allowWhatsApp = value);
+                      },
+                    ),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    _NoteCard(controller: _noteController),
+                    const SizedBox(height: AppDimensions.spaceM),
+                    _MapCard(
+                      latitude: _readCoordinate(_latitudeController),
+                      longitude: _readCoordinate(_longitudeController),
+                      latitudeController: _latitudeController,
+                      longitudeController: _longitudeController,
+                      latitudeValidator: _latitudeValidator,
+                      longitudeValidator: _longitudeValidator,
+                      onUseCurrentLocation: _useCurrentLocation,
+                      onPointSelected: _setMapPoint,
+                      onManualCoordinateChanged: () => setState(() {}),
+                      hasSelectedLocation:
+                          _readCoordinate(_latitudeController) != null &&
+                          _readCoordinate(_longitudeController) != null,
+                    ),
+                  ],
+                ),
+              ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: _showExtraContactsComingSoon,
+        backgroundColor: AppColors.primary,
+        foregroundColor: AppColors.onPrimary,
+        child: const Icon(Icons.add_rounded),
+      ),
+      bottomNavigationBar: PetcareBottomNavBar(
+        currentIndex: 2,
+        onTap: _handleBottomNavTap,
+      ),
+    );
+  }
+}
+
+class _PetHero extends StatelessWidget {
+  const _PetHero({required this.pet});
+
+  final PetUiModel pet;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardBackground,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.18 : 0.06),
+            blurRadius: 16,
+            offset: const Offset(0, 5),
+          ),
+        ],
+      ),
+      clipBehavior: Clip.antiAlias,
+      child: AspectRatio(
+        aspectRatio: 16 / 7.5,
+        child: _PetImage(pet: pet),
+      ),
+    );
+  }
+}
+
+class _LostStatusCard extends StatelessWidget {
+  const _LostStatusCard({
+    required this.hasActiveLostReport,
+    required this.isResolving,
+    required this.onMarkFound,
+  });
+
+  final bool hasActiveLostReport;
+  final bool isResolving;
+  final VoidCallback onMarkFound;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ModeCard(
+      child: Row(
+        children: [
+          Container(
+            width: 46,
+            height: 46,
+            decoration: const BoxDecoration(
+              color: AppColors.primaryVariant,
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              hasActiveLostReport
+                  ? Icons.location_on_outlined
+                  : Icons.check_circle_outline_rounded,
+              color: AppColors.primary,
+            ),
+          ),
+          const SizedBox(width: AppDimensions.spaceM),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  hasActiveLostReport ? 'Lost mode is active' : 'Pet is Safe',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                    height: 1.1,
+                  ),
+                ),
+                const SizedBox(height: 3),
+                Text(
+                  hasActiveLostReport
+                      ? 'Tap to mark this pet as found'
+                      : 'Tap save to activate lost mode',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: AppColors.grey700,
+                    fontWeight: FontWeight.w500,
+                    height: 1.2,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: AppDimensions.spaceS),
+          Switch(
+            value: hasActiveLostReport,
+            onChanged: hasActiveLostReport && !isResolving
+                ? (_) => onMarkFound()
+                : null,
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _LostSettingsCard extends StatelessWidget {
+  const _LostSettingsCard({
+    required this.enabled,
+    required this.exposeMedicalInfo,
+    required this.hasMedicalInfo,
+    required this.onChanged,
+    required this.onExposeMedicalInfoChanged,
+  });
+
+  final bool enabled;
+  final bool exposeMedicalInfo;
+  final bool hasMedicalInfo;
+  final ValueChanged<bool> onChanged;
+  final ValueChanged<bool> onExposeMedicalInfoChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ModeCard(
+      title: 'Lost mode settings',
+      child: Column(
+        children: [
+          Row(
+            children: [
+              Container(
+                width: 34,
+                height: 34,
+                decoration: const BoxDecoration(
+                  color: Color(0xFFEDEBFF),
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(
+                  Icons.nfc_rounded,
+                  color: AppColors.petQuickActionNfc,
+                  size: 18,
+                ),
+              ),
+              const SizedBox(width: AppDimensions.spaceM),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'NFC Scan Notifications',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                        height: 1.1,
+                      ),
+                    ),
+                    const SizedBox(height: 3),
+                    Text(
+                      "Get notified when someone scans your pet's tag",
+                      style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: AppColors.grey700,
+                        fontWeight: FontWeight.w500,
+                        height: 1.2,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              Switch(value: enabled, onChanged: onChanged),
+            ],
+          ),
+          if (hasMedicalInfo) ...[
+            const Divider(height: AppDimensions.spaceXL),
+            Row(
+              children: [
+                const Icon(
+                  Icons.medical_information_outlined,
+                  color: AppColors.primary,
+                  size: 22,
+                ),
+                const SizedBox(width: AppDimensions.spaceM),
+                Expanded(
+                  child: Text(
+                    'Show allergy info publicly',
+                    style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                      height: 1.1,
+                    ),
+                  ),
+                ),
+                Switch(
+                  value: exposeMedicalInfo,
+                  onChanged: onExposeMedicalInfoChanged,
+                ),
+              ],
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+}
+
+class _EmergencyContactCard extends StatelessWidget {
+  const _EmergencyContactCard({
+    required this.contactNameController,
+    required this.contactPhoneController,
+    required this.nameValidator,
+    required this.phoneValidator,
+    required this.onAddTap,
+    required this.allowCall,
+    required this.allowWhatsApp,
+    required this.onAllowCallChanged,
+    required this.onAllowWhatsAppChanged,
+  });
+
+  final TextEditingController contactNameController;
+  final TextEditingController contactPhoneController;
+  final FormFieldValidator<String> nameValidator;
+  final FormFieldValidator<String> phoneValidator;
+  final VoidCallback onAddTap;
+  final bool allowCall;
+  final bool allowWhatsApp;
+  final ValueChanged<bool> onAllowCallChanged;
+  final ValueChanged<bool> onAllowWhatsAppChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ModeCard(
+      title: AppStrings.lostPetEmergencyContacts,
+      trailing: TextButton.icon(
+        onPressed: onAddTap,
+        icon: const Icon(Icons.add_rounded, size: 16),
+        label: const Text('Add'),
+        style: TextButton.styleFrom(
+          backgroundColor: AppColors.primaryVariant,
+          foregroundColor: AppColors.primary,
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+        ),
+      ),
+      child: Column(
+        children: [
+          TextFormField(
+            controller: contactNameController,
+            validator: nameValidator,
+            decoration: _inputDecoration(
+              context,
+              labelText: AppStrings.lostModeContactName,
+            ),
+          ),
+          const SizedBox(height: AppDimensions.spaceS),
+          TextFormField(
+            controller: contactPhoneController,
+            validator: phoneValidator,
+            keyboardType: TextInputType.phone,
+            inputFormatters: AppInputFormatters.phone(),
+            decoration: _inputDecoration(
+              context,
+              labelText: AppStrings.lostModeContactPhone,
+            ),
+          ),
+          const Divider(height: AppDimensions.spaceXL),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            value: allowCall,
+            onChanged: onAllowCallChanged,
+            title: const Text('Show phone for calls'),
+          ),
+          SwitchListTile.adaptive(
+            contentPadding: EdgeInsets.zero,
+            value: allowWhatsApp,
+            onChanged: onAllowWhatsAppChanged,
+            title: const Text('Show WhatsApp contact'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _NoteCard extends StatelessWidget {
+  const _NoteCard({required this.controller});
+
+  final TextEditingController controller;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ModeCard(
+      title: AppStrings.lostModeNoteLabel,
+      child: TextFormField(
+        controller: controller,
+        minLines: 4,
+        maxLines: 7,
+        maxLength: 500,
+        decoration: _inputDecoration(
+          context,
+          hintText: AppStrings.lostModeNoteHint,
+        ),
+      ),
+    );
+  }
+}
+
+class _MapCard extends StatelessWidget {
+  const _MapCard({
+    required this.latitude,
+    required this.longitude,
+    required this.latitudeController,
+    required this.longitudeController,
+    required this.latitudeValidator,
+    required this.longitudeValidator,
+    required this.onUseCurrentLocation,
+    required this.onPointSelected,
+    required this.onManualCoordinateChanged,
+    required this.hasSelectedLocation,
+  });
+
+  final double? latitude;
+  final double? longitude;
+  final TextEditingController latitudeController;
+  final TextEditingController longitudeController;
+  final FormFieldValidator<String> latitudeValidator;
+  final FormFieldValidator<String> longitudeValidator;
+  final VoidCallback onUseCurrentLocation;
+  final ValueChanged<LostPetMapPoint> onPointSelected;
+  final VoidCallback onManualCoordinateChanged;
+  final bool hasSelectedLocation;
+
+  @override
+  Widget build(BuildContext context) {
+    return _ModeCard(
+      title: AppStrings.lostModeLocationLabel,
+      trailing: TextButton.icon(
+        onPressed: onUseCurrentLocation,
+        icon: const Icon(Icons.my_location_rounded, size: 16),
+        label: const Text('Use current'),
+        style: TextButton.styleFrom(
+          foregroundColor: AppColors.primary,
+          visualDensity: VisualDensity.compact,
+          padding: const EdgeInsets.symmetric(horizontal: 10),
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          LostPetMapPreview(
+            height: 210,
+            latitude: latitude,
+            longitude: longitude,
+            onPointSelected: onPointSelected,
+          ),
+          const SizedBox(height: AppDimensions.spaceS),
+          Row(
+            children: [
+              Expanded(
+                child: TextFormField(
+                  controller: latitudeController,
+                  validator: latitudeValidator,
+                  onChanged: (_) => onManualCoordinateChanged(),
+                  keyboardType: const TextInputType.numberWithOptions(
+                    signed: true,
+                    decimal: true,
+                  ),
+                  decoration: _inputDecoration(
+                    context,
+                    labelText: 'Latitude',
+                    hintText: '4.711000',
+                  ),
+                ),
+              ),
+              const SizedBox(width: AppDimensions.spaceS),
+              Expanded(
+                child: TextFormField(
+                  controller: longitudeController,
+                  validator: longitudeValidator,
+                  onChanged: (_) => onManualCoordinateChanged(),
+                  keyboardType: const TextInputType.numberWithOptions(
+                    signed: true,
+                    decimal: true,
+                  ),
+                  decoration: _inputDecoration(
+                    context,
+                    labelText: 'Longitude',
+                    hintText: '-74.072100',
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppDimensions.spaceS),
+          Row(
+            children: [
+              Icon(
+                hasSelectedLocation
+                    ? Icons.check_circle_rounded
+                    : Icons.touch_app_rounded,
+                size: 18,
+                color: hasSelectedLocation
+                    ? AppColors.primary
+                    : AppColors.grey700,
+              ),
+              const SizedBox(width: AppDimensions.spaceS),
+              Expanded(
+                child: Text(
+                  hasSelectedLocation
+                      ? 'Location selected'
+                      : 'Tap the online map or enter coordinates manually',
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                    color: hasSelectedLocation
+                        ? AppColors.primary
+                        : AppColors.grey700,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _ModeCard extends StatelessWidget {
+  const _ModeCard({this.title, this.trailing, required this.child});
+
+  final String? title;
+  final Widget? trailing;
+  final Widget child;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return Container(
+      padding: const EdgeInsets.all(AppDimensions.spaceM),
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark
+            : AppColors.petCardBackground,
+        borderRadius: BorderRadius.circular(22),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: isDark ? 0.16 : 0.05),
+            blurRadius: 14,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          if (title != null) ...[
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    title!.toUpperCase(),
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: isDark
+                          ? AppColors.onSurfaceDark.withValues(alpha: 0.72)
+                          : AppColors.grey700,
+                      fontSize: 11,
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                ?trailing,
+              ],
+            ),
+            const SizedBox(height: AppDimensions.spaceM),
+          ],
+          child,
+        ],
+      ),
+    );
+  }
+}
+
+class _PetImage extends StatelessWidget {
+  const _PetImage({required this.pet});
+
+  final PetUiModel pet;
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final value = pet.effectivePhotoPath?.trim();
+    if (value == null || value.isEmpty) {
+      return _PetImagePlaceholder(isDark: isDark);
+    }
+
+    if (pet.isPhotoRemote) {
+      return CachedNetworkImage(
+        imageUrl: value,
+        cacheManager: AppImageCacheManager.instance,
+        fit: BoxFit.cover,
+        placeholder: (_, _) => _PetImagePlaceholder(isDark: isDark),
+        errorWidget: (_, _, _) => _PetImagePlaceholder(isDark: isDark),
+      );
+    }
+
+    return Image.file(
+      File(value),
+      fit: BoxFit.cover,
+      errorBuilder: (_, _, _) => _PetImagePlaceholder(isDark: isDark),
+    );
+  }
+}
+
+class _PetImagePlaceholder extends StatelessWidget {
+  const _PetImagePlaceholder({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: isDark
+          ? AppColors.petCardQuickActionBgDark
+          : AppColors.petCardQuickActionBg,
+      alignment: Alignment.center,
+      child: Icon(
+        Icons.pets_rounded,
+        size: AppDimensions.iconXL,
+        color: isDark
+            ? AppColors.quickActionIconTintDark
+            : AppColors.quickActionIconTint,
+      ),
+    );
+  }
+}
+
+InputDecoration _inputDecoration(
+  BuildContext context, {
+  String? labelText,
+  String? hintText,
+}) {
+  final isDark = Theme.of(context).brightness == Brightness.dark;
+  final fillColor = isDark ? AppColors.secondaryDark : AppColors.secondary;
+  final borderColor = isDark ? AppColors.grey700 : AppColors.grey500;
+  final hintColor = isDark
+      ? AppColors.onSurfaceDark.withValues(alpha: 0.55)
+      : AppColors.grey500;
+
+  return InputDecoration(
+    labelText: labelText,
+    hintText: hintText,
+    hintStyle: Theme.of(context).textTheme.bodyMedium?.copyWith(
+      color: hintColor,
+      fontWeight: FontWeight.w400,
+    ),
+    filled: true,
+    fillColor: fillColor,
+    contentPadding: const EdgeInsets.symmetric(horizontal: 18, vertical: 18),
+    enabledBorder: _inputBorder(borderColor),
+    focusedBorder: _focusedInputBorder,
+    disabledBorder: _inputBorder(borderColor),
+    errorBorder: _errorInputBorder,
+    focusedErrorBorder: _errorInputBorder,
+  );
+}
+
+OutlineInputBorder _inputBorder(Color color) => OutlineInputBorder(
+  borderRadius: const BorderRadius.all(Radius.circular(18)),
+  borderSide: BorderSide(color: color, width: 1.5),
+);
+
+const OutlineInputBorder _focusedInputBorder = OutlineInputBorder(
+  borderRadius: BorderRadius.all(Radius.circular(18)),
+  borderSide: BorderSide(color: AppColors.primary, width: 1.5),
+);
+
+const OutlineInputBorder _errorInputBorder = OutlineInputBorder(
+  borderRadius: BorderRadius.all(Radius.circular(18)),
+  borderSide: BorderSide(color: AppColors.error, width: 1.5),
+);

--- a/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
+++ b/lib/presentation/pages/pets/pet_detail/pet_detail_screen.dart
@@ -14,7 +14,6 @@ import '../../../../core/models/pet_model.dart';
 import '../../../../core/models/smart_alert_model.dart';
 import '../../../../core/network/api_exception.dart';
 import '../../../../core/services/app_image_cache_manager.dart';
-import '../../../../core/services/connectivity_sync_service.dart';
 import '../../../../core/services/event_service.dart';
 import '../../../../core/services/pet_service.dart';
 import '../../../../core/services/profile_photo_service.dart';
@@ -49,13 +48,26 @@ class PetDetailScreen extends StatefulWidget {
 class _PetDetailScreenState extends State<PetDetailScreen>
     with SingleTickerProviderStateMixin {
   late final TabController _tabController;
-  final ConnectivitySyncService _connectivitySyncService =
-      ConnectivitySyncService();
   final PetService _petService = PetService();
   final EventService _eventService = EventService();
   final SmartFeatureService _smartFeatureService = SmartFeatureService();
   final ProfilePhotoService _photoService = ProfilePhotoService();
   final TelemetryService _telemetryService = TelemetryService();
+
+  Future<void> _goToAddPet() async {
+    final result = await Navigator.pushNamed(context, Routes.addPet);
+    if (!mounted) {
+      return;
+    }
+
+    if (result == true) {
+      _hasMutatedPet = true;
+      await _loadPetDetail();
+      await _telemetryService.logAddPetExecutionIfPending(
+        endTime: DateTime.now(),
+      );
+    }
+  }
 
   Future<void> _goToAddVaccine() async {
     final result = await Navigator.pushNamed(
@@ -219,92 +231,15 @@ class _PetDetailScreenState extends State<PetDetailScreen>
   }
 
   Future<void> _toggleLostMode() async {
-    final isLost = _pet.status == 'lost';
-
-    if (!isLost) {
-      final confirmed = await showDialog<bool>(
-        context: context,
-        builder: (dialogContext) {
-          return AlertDialog(
-            title: const Text(AppStrings.petLostConfirmTitle),
-            content: Text('${AppStrings.petLostConfirmMessage} (${_pet.name})'),
-            actions: [
-              TextButton(
-                onPressed: () => Navigator.of(dialogContext).pop(false),
-                child: const Text(AppStrings.petLostConfirmCancel),
-              ),
-              FilledButton(
-                onPressed: () => Navigator.of(dialogContext).pop(true),
-                child: const Text(AppStrings.petLostConfirmAction),
-              ),
-            ],
-          );
-        },
-      );
-
-      if (confirmed != true) {
-        return;
-      }
+    final changed = await Navigator.of(
+      context,
+    ).pushNamed(Routes.lostMode, arguments: _pet);
+    if (!mounted || changed != true) {
+      return;
     }
-
-    try {
-      final wasOffline = !await _connectivitySyncService.hasInternetAccess();
-
-      if (isLost) {
-        await _petService.markPetAsFound(_pet.id);
-      } else {
-        await _petService.markPetAsLost(_pet.id);
-      }
-
-      if (!mounted) {
-        return;
-      }
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            _lostModeMessage(
-              petName: _pet.name,
-              wasLost: isLost,
-              wasOffline: wasOffline,
-            ),
-          ),
-        ),
-      );
-
-      _hasMutatedPet = true;
-      await _loadPetDetail();
-    } on ApiException catch (error) {
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(error.message)));
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
-    }
-  }
-
-  String _lostModeMessage({
-    required String petName,
-    required bool wasLost,
-    required bool wasOffline,
-  }) {
-    if (wasOffline) {
-      return wasLost
-          ? AppStrings.petMarkedAsFoundOfflineMessage
-          : AppStrings.petMarkedAsLostOfflineMessage;
-    }
-
-    return wasLost
-        ? '$petName ${AppStrings.petMarkedAsFoundMessage}'
-        : '$petName ${AppStrings.petMarkedAsLostMessage}';
+    _hasMutatedPet = true;
+    await _petService.getPets(forceRefresh: true);
+    await _loadPetDetail();
   }
 
   Future<void> _toggleNfc() async {
@@ -491,10 +426,11 @@ class _PetDetailScreenState extends State<PetDetailScreen>
             ? AppColors.backgroundDark
             : AppColors.background,
         body: _buildBody(),
+        floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
         floatingActionButton: QuickActionsFab(
-          onAddPet: () {},
-          onAddVaccine: () {},
-          onAddEvent: () {},
+          onAddPet: _goToAddPet,
+          onAddVaccine: _goToAddVaccine,
+          onAddEvent: _goToAddEvent,
         ),
       ),
     );

--- a/lib/presentation/pages/pets/pets_page.dart
+++ b/lib/presentation/pages/pets/pets_page.dart
@@ -4,7 +4,6 @@ import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_dimensions.dart';
 import '../../../core/constants/app_strings.dart';
 import '../../../core/network/api_exception.dart';
-import '../../../core/services/connectivity_sync_service.dart';
 import '../../../core/services/pet_service.dart';
 import '../../../core/services/profile_photo_service.dart';
 import '../../../core/services/telemetry_service.dart';
@@ -26,8 +25,6 @@ class PetsPage extends StatefulWidget {
 }
 
 class _PetsPageState extends State<PetsPage> {
-  final ConnectivitySyncService _connectivitySyncService =
-      ConnectivitySyncService();
   final PetService _petService = PetService();
   final ProfilePhotoService _photoService = ProfilePhotoService();
   final TelemetryService _telemetryService = TelemetryService();
@@ -45,14 +42,14 @@ class _PetsPageState extends State<PetsPage> {
     _loadPets();
   }
 
-  Future<void> _loadPets() async {
+  Future<void> _loadPets({bool forceRefresh = false}) async {
     setState(() {
       _isLoadingPets = true;
       _loadErrorMessage = null;
     });
 
     try {
-      final pets = await _petService.getPets();
+      final pets = await _petService.getPets(forceRefresh: forceRefresh);
       final mappedPetsRaw = pets
           .map((pet) => pet.toUiModel())
           .toList(growable: false);
@@ -133,7 +130,7 @@ class _PetsPageState extends State<PetsPage> {
     if (!mounted) {
       return;
     }
-    await _loadPets();
+    await _loadPets(forceRefresh: true);
     if (_loadErrorMessage == null) {
       await _telemetryService.logAddPetExecutionIfPending(
         endTime: DateTime.now(),
@@ -159,96 +156,18 @@ class _PetsPageState extends State<PetsPage> {
     await _loadPets();
   }
 
-  Future<bool> _confirmMarkAsLost(PetUiModel pet) async {
-    final result = await showDialog<bool>(
-      context: context,
-      builder: (dialogContext) {
-        return AlertDialog(
-          title: const Text(AppStrings.petLostConfirmTitle),
-          content: Text('${AppStrings.petLostConfirmMessage} (${pet.name})'),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(dialogContext).pop(false),
-              child: const Text(AppStrings.petLostConfirmCancel),
-            ),
-            FilledButton(
-              onPressed: () => Navigator.of(dialogContext).pop(true),
-              child: const Text(AppStrings.petLostConfirmAction),
-            ),
-          ],
-        );
-      },
-    );
-
-    return result ?? false;
-  }
-
   Future<void> _toggleLostMode(PetUiModel pet) async {
-    final isLost = pet.status == 'lost';
-
-    if (!isLost) {
-      final confirmed = await _confirmMarkAsLost(pet);
-      if (!confirmed) {
-        return;
-      }
+    final changed = await Navigator.of(
+      context,
+    ).pushNamed(Routes.lostMode, arguments: pet);
+    if (!mounted || changed != true) {
+      return;
     }
-
-    try {
-      final wasOffline = !await _connectivitySyncService.hasInternetAccess();
-
-      if (isLost) {
-        await _petService.markPetAsFound(pet.id);
-      } else {
-        await _petService.markPetAsLost(pet.id);
-      }
-
-      if (!mounted) {
-        return;
-      }
-
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(
-          content: Text(
-            _lostModeMessage(
-              petName: pet.name,
-              wasLost: isLost,
-              wasOffline: wasOffline,
-            ),
-          ),
-        ),
-      );
-      await _loadPets();
-    } on ApiException catch (error) {
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(error.message)));
-    } catch (_) {
-      if (!mounted) {
-        return;
-      }
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(const SnackBar(content: Text(AppStrings.petsLoadError)));
-    }
+    await _loadPets(forceRefresh: true);
   }
 
-  String _lostModeMessage({
-    required String petName,
-    required bool wasLost,
-    required bool wasOffline,
-  }) {
-    if (wasOffline) {
-      return wasLost
-          ? AppStrings.petMarkedAsFoundOfflineMessage
-          : AppStrings.petMarkedAsLostOfflineMessage;
-    }
-
-    return wasLost
-        ? '$petName ${AppStrings.petMarkedAsFoundMessage}'
-        : '$petName ${AppStrings.petMarkedAsLostMessage}';
+  void _openLostPets() {
+    Navigator.of(context).pushNamed(Routes.lostPets);
   }
 
   Future<void> _handleNfcTap(PetUiModel pet) async {
@@ -342,6 +261,7 @@ class _PetsPageState extends State<PetsPage> {
               activeFilter: _activeFilter,
               onFilterChanged: _onFilterChanged,
               onSearchChanged: _onSearchChanged,
+              onLostPetsTap: _openLostPets,
             ),
             Expanded(child: _buildBody()),
           ],
@@ -406,6 +326,7 @@ class _PageHeader extends StatelessWidget {
     required this.activeFilter,
     required this.onFilterChanged,
     required this.onSearchChanged,
+    required this.onLostPetsTap,
   });
 
   final int petCount;
@@ -413,6 +334,7 @@ class _PageHeader extends StatelessWidget {
   final PetFilter activeFilter;
   final ValueChanged<PetFilter> onFilterChanged;
   final ValueChanged<String> onSearchChanged;
+  final VoidCallback onLostPetsTap;
 
   @override
   Widget build(BuildContext context) {
@@ -438,6 +360,15 @@ class _PageHeader extends StatelessWidget {
               const Spacer(),
               if (showCount) ...[PetCountPill(count: petCount, isDark: isDark)],
             ],
+          ),
+          const SizedBox(height: AppDimensions.spaceS),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: TextButton.icon(
+              onPressed: onLostPetsTap,
+              icon: const Icon(Icons.location_on_outlined, size: 18),
+              label: const Text(AppStrings.lostPetsTitle),
+            ),
           ),
           const SizedBox(height: AppDimensions.spaceM),
           PetsSearchBar(onChanged: onSearchChanged),

--- a/lib/presentation/pages/pets/widgets/pet_card.dart
+++ b/lib/presentation/pages/pets/widgets/pet_card.dart
@@ -261,13 +261,19 @@ class _PetCardStatusBadge extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final backgroundColor = switch (status) {
-      'healthy' => isDark? AppColors.positiveBackgroundDark : AppColors.positiveBackground,
-      'lost' => isDark? AppColors.negativeBackgroundDark : AppColors.negativeBackground,
+      'healthy' =>
+        isDark
+            ? AppColors.positiveBackgroundDark
+            : AppColors.positiveBackground,
+      'lost' =>
+        isDark
+            ? AppColors.negativeBackgroundDark
+            : AppColors.negativeBackground,
       _ => AppColors.petStatusAttentionBg,
     };
     final textColor = switch (status) {
-      'healthy' => isDark? AppColors.positiveTextDark : AppColors.positiveText,
-      'lost' => isDark? AppColors.negativeTextDark : AppColors.negativeText,
+      'healthy' => isDark ? AppColors.positiveTextDark : AppColors.positiveText,
+      'lost' => isDark ? AppColors.negativeTextDark : AppColors.negativeText,
       _ => AppColors.petStatusAttentionText,
     };
     final label = switch (status) {
@@ -464,7 +470,7 @@ class _PetCardBottomActions extends StatelessWidget {
           Container(width: 1, color: dividerColor),
           Expanded(
             child: _PetCardActionItem(
-              label: petStatus == 'lost' ? 'Found' : 'Lost Mode',
+              label: petStatus == 'lost' ? 'Manage' : 'Lost Mode',
               assetPath: _PetCardAssets.lostMode,
               color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
               onTap: onLostModeTap,

--- a/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
+++ b/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
@@ -1,14 +1,24 @@
+import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
 
+import '../../../app/routes.dart';
 import '../../../core/constants/app_colors.dart';
 import '../../../core/constants/app_dimensions.dart';
 import '../../../core/constants/app_strings.dart';
+import '../../../core/models/lost_pet_model.dart';
+import '../../../core/models/notification_model.dart';
 import '../../../core/models/pet_model.dart';
 import '../../../core/models/smart_alert_model.dart';
 import '../../../core/network/api_exception.dart';
+import '../../../core/services/app_image_cache_manager.dart';
+import '../../../core/services/app_preferences_service.dart';
+import '../../../core/services/lost_pet_service.dart';
 import '../../../core/services/pet_service.dart';
 import '../../../core/services/connectivity_sync_service.dart';
+import '../../../core/services/notification_service.dart';
 import '../../../core/services/smart_feature_service.dart';
+import '../lost_pets/lost_pet_sighting_detail_page.dart';
 import '../../../shared/widgets/smart_alert_card.dart';
 
 class SmartAlertsPage extends StatefulWidget {
@@ -23,9 +33,15 @@ class SmartAlertsPage extends StatefulWidget {
 class _SmartAlertsPageState extends State<SmartAlertsPage> {
   final PetService _petService = PetService();
   final SmartFeatureService _smartFeatureService = SmartFeatureService();
+  final NotificationService _notificationService = NotificationService();
+  final LostPetService _lostPetService = LostPetService();
+  final AppPreferencesService _preferencesService = AppPreferencesService();
 
   List<PetModel> _pets = const [];
   List<SmartAlertItem> _alerts = const [];
+  List<NotificationModel> _notifications = const [];
+  Map<String, LostPetReportModel> _lostPetReportsByReportId = const {};
+  final Set<String> _dismissedNotificationIds = <String>{};
   String? _selectedPetId;
   bool _isLoading = false;
   String? _errorMessage;
@@ -52,7 +68,16 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
     });
 
     try {
+      final dismissedIds = await _preferencesService
+          .getDismissedLostPetNotificationIds();
+      _dismissedNotificationIds
+        ..clear()
+        ..addAll(dismissedIds);
       final pets = await _petService.getPets();
+      final notifications = await _loadBackendNotificationsBestEffort();
+      final reportMap = await _loadLostPetReportsForNotifications(
+        notifications,
+      );
 
       final alertGroups = await Future.wait(
         pets.map((pet) async {
@@ -93,6 +118,13 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
 
       setState(() {
         _pets = pets;
+        _notifications = notifications
+            .where(
+              (notification) =>
+                  !_dismissedNotificationIds.contains(notification.id),
+            )
+            .toList(growable: false);
+        _lostPetReportsByReportId = reportMap;
         _alerts = alerts;
         _selectedPetId =
             normalizedSelection != null &&
@@ -123,6 +155,49 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
     }
   }
 
+  Future<List<NotificationModel>> _loadBackendNotificationsBestEffort() async {
+    try {
+      final notifications = await _notificationService.getMyNotifications();
+      final sightings = notifications
+          .where((notification) => notification.type == 'lost_pet_sighting')
+          .toList(growable: false);
+      return _latestSightingNotifications(sightings);
+    } catch (_) {
+      return const <NotificationModel>[];
+    }
+  }
+
+  Future<Map<String, LostPetReportModel>> _loadLostPetReportsForNotifications(
+    List<NotificationModel> notifications,
+  ) async {
+    final entries = <MapEntry<String, LostPetReportModel>>[];
+    for (final notification in notifications) {
+      final reportId = notification.actionReportId.trim();
+      if (reportId.isEmpty) {
+        continue;
+      }
+      try {
+        final report = await _lostPetService.getLostPetDetail(reportId);
+        entries.add(MapEntry(reportId, report));
+      } catch (_) {
+        // The notification can still render without the report payload.
+      }
+    }
+    return Map<String, LostPetReportModel>.fromEntries(entries);
+  }
+
+  List<NotificationModel> _latestSightingNotifications(
+    List<NotificationModel> notifications,
+  ) {
+    final sorted = [...notifications]
+      ..sort((a, b) {
+        final aDate = a.dateSent ?? DateTime.fromMillisecondsSinceEpoch(0);
+        final bDate = b.dateSent ?? DateTime.fromMillisecondsSinceEpoch(0);
+        return bDate.compareTo(aDate);
+      });
+    return sorted.take(1).toList(growable: false);
+  }
+
   List<SmartAlertItem> get _visibleAlerts {
     final selectedPetId = _selectedPetId;
     if (selectedPetId == null) {
@@ -135,6 +210,28 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
 
   int _countForPet(String petId) {
     return _alerts.where((item) => item.petId == petId).length;
+  }
+
+  Future<void> _dismissNotification(NotificationModel notification) async {
+    setState(() {
+      _dismissedNotificationIds.add(notification.id);
+      _notifications = _notifications
+          .where((item) => item.id != notification.id)
+          .toList(growable: false);
+    });
+    await _preferencesService.setDismissedLostPetNotificationIds(
+      _dismissedNotificationIds,
+    );
+  }
+
+  void _openLostPetSighting(NotificationModel notification) {
+    if (!notification.hasLostPetReport) {
+      return;
+    }
+    Navigator.of(context).pushNamed(
+      Routes.lostPetSightingDetail,
+      arguments: LostPetSightingDetailArgs(notification: notification),
+    );
   }
 
   @override
@@ -196,6 +293,9 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
       );
     }
 
+    final visibleAlerts = _visibleAlerts;
+    final hasContent = _notifications.isNotEmpty || visibleAlerts.isNotEmpty;
+
     return Column(
       children: [
         const SizedBox(height: AppDimensions.spaceS),
@@ -204,7 +304,7 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
         _buildFilterBar(),
         const SizedBox(height: AppDimensions.spaceM),
         Expanded(
-          child: _visibleAlerts.isEmpty
+          child: !hasContent
               ? _buildEmptyState()
               : RefreshIndicator(
                   onRefresh: _loadAlerts,
@@ -213,11 +313,25 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
                       top: AppDimensions.spaceS,
                       bottom: AppDimensions.spaceXXL,
                     ),
-                    itemCount: _visibleAlerts.length,
+                    itemCount: _notifications.length + visibleAlerts.length,
                     separatorBuilder: (_, _) =>
                         const SizedBox(height: AppDimensions.spaceS),
                     itemBuilder: (context, index) {
-                      final alert = _visibleAlerts[index];
+                      if (index < _notifications.length) {
+                        return _LostPetNotificationCard(
+                          notification: _notifications[index],
+                          report:
+                              _lostPetReportsByReportId[_notifications[index]
+                                  .actionReportId],
+                          onDismiss: () =>
+                              _dismissNotification(_notifications[index]),
+                          onOpen: () =>
+                              _openLostPetSighting(_notifications[index]),
+                        );
+                      }
+
+                      final alert =
+                          visibleAlerts[index - _notifications.length];
                       return SmartAlertCard(
                         suggestion: alert.suggestion,
                         petName: alert.petName,
@@ -339,6 +453,470 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
           ),
         ),
       ),
+    );
+  }
+}
+
+class _LostPetNotificationCard extends StatefulWidget {
+  const _LostPetNotificationCard({
+    required this.notification,
+    required this.report,
+    required this.onDismiss,
+    required this.onOpen,
+  });
+
+  final NotificationModel notification;
+  final LostPetReportModel? report;
+  final VoidCallback onDismiss;
+  final VoidCallback onOpen;
+
+  @override
+  State<_LostPetNotificationCard> createState() =>
+      _LostPetNotificationCardState();
+}
+
+class _LostPetNotificationCardState extends State<_LostPetNotificationCard> {
+  bool _isExpanded = false;
+
+  Future<void> _call() async {
+    final phone = widget.notification.actionPhone.trim();
+    if (phone.isEmpty) {
+      return;
+    }
+    await launchUrl(Uri(scheme: 'tel', path: phone));
+  }
+
+  Future<void> _openWhatsApp() async {
+    final phone = widget.notification.actionWhatsapp.trim();
+    if (phone.isEmpty) {
+      return;
+    }
+    final normalizedPhone = phone.replaceAll(RegExp(r'[^0-9+]'), '');
+    await launchUrl(
+      Uri.parse('https://wa.me/$normalizedPhone'),
+      mode: LaunchMode.externalApplication,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final notification = widget.notification;
+    final report = widget.report;
+    if (notification.type != 'lost_pet_sighting') {
+      return const SizedBox.shrink();
+    }
+
+    final hasActions =
+        notification.hasCallAction || notification.hasWhatsAppAction;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    final backgroundColor = isDark
+        ? AppColors.smartAlertInfoBgDark
+        : AppColors.smartAlertInfoBg;
+    final textColor = isDark
+        ? AppColors.smartAlertInfoTextDark
+        : AppColors.smartAlertInfoText;
+
+    return Dismissible(
+      key: ValueKey('lost-pet-notification-${notification.id}'),
+      direction: DismissDirection.endToStart,
+      onDismissed: (_) => widget.onDismiss(),
+      background: Container(
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.pageHorizontalPadding,
+        ),
+        padding: const EdgeInsets.symmetric(horizontal: AppDimensions.spaceL),
+        decoration: BoxDecoration(
+          color: AppColors.negativeText.withValues(alpha: 0.12),
+          borderRadius: BorderRadius.circular(AppDimensions.radiusL),
+        ),
+        alignment: Alignment.centerRight,
+        child: const Icon(
+          Icons.delete_outline_rounded,
+          color: AppColors.negativeText,
+        ),
+      ),
+      child: AnimatedContainer(
+        duration: const Duration(milliseconds: 180),
+        margin: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.pageHorizontalPadding,
+        ),
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.spaceM,
+          vertical: AppDimensions.spaceM,
+        ),
+        decoration: BoxDecoration(
+          color: backgroundColor,
+          borderRadius: BorderRadius.circular(AppDimensions.radiusL),
+        ),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            InkWell(
+              onTap: widget.notification.hasLostPetReport
+                  ? widget.onOpen
+                  : () => setState(() => _isExpanded = !_isExpanded),
+              borderRadius: BorderRadius.circular(AppDimensions.radiusM),
+              child: Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  _NotificationPetPhoto(
+                    notification: notification,
+                    report: report,
+                  ),
+                  const SizedBox(width: AppDimensions.spaceM),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          _finderLabel(notification, report),
+                          maxLines: 2,
+                          overflow: TextOverflow.ellipsis,
+                          style: Theme.of(context).textTheme.titleSmall
+                              ?.copyWith(
+                                color: textColor,
+                                fontWeight: FontWeight.w800,
+                                height: 1.15,
+                              ),
+                        ),
+                        const SizedBox(height: AppDimensions.spaceS),
+                        _NotificationSummary(
+                          notification: notification,
+                          report: report,
+                          textColor: textColor,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(width: AppDimensions.spaceXS),
+                  _NotificationIconButton(
+                    icon: _isExpanded
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                    color: textColor,
+                    onPressed: () => setState(() => _isExpanded = !_isExpanded),
+                  ),
+                  _NotificationIconButton(
+                    icon: Icons.close_rounded,
+                    color: textColor,
+                    onPressed: widget.onDismiss,
+                  ),
+                ],
+              ),
+            ),
+            if (_isExpanded && notification.dateSent != null) ...[
+              const SizedBox(height: AppDimensions.spaceS),
+              Text(
+                _formatDate(notification.dateSent!),
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                  color: textColor.withValues(alpha: 0.72),
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+            if (_isExpanded &&
+                (notification.hasLostPetReport || hasActions)) ...[
+              const SizedBox(height: AppDimensions.spaceS),
+              Wrap(
+                spacing: AppDimensions.spaceS,
+                runSpacing: AppDimensions.spaceS,
+                children: [
+                  if (notification.hasLostPetReport)
+                    _NotificationActionChip(
+                      icon: Icons.open_in_new_rounded,
+                      label: 'View update',
+                      color: textColor,
+                      onPressed: widget.onOpen,
+                    ),
+                  if (notification.hasCallAction)
+                    _NotificationActionChip(
+                      icon: Icons.call_rounded,
+                      label: AppStrings.lostPetCall,
+                      color: textColor,
+                      onPressed: _call,
+                    ),
+                  if (notification.hasWhatsAppAction)
+                    _NotificationActionChip(
+                      icon: Icons.chat_bubble_outline_rounded,
+                      label: AppStrings.lostPetWhatsApp,
+                      color: textColor,
+                      onPressed: _openWhatsApp,
+                    ),
+                ],
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime value) {
+    final local = value.toLocal();
+    final hour = local.hour.toString().padLeft(2, '0');
+    final minute = local.minute.toString().padLeft(2, '0');
+    return '${local.day}/${local.month}/${local.year} $hour:$minute';
+  }
+
+  String _finderLabel(
+    NotificationModel notification,
+    LostPetReportModel? report,
+  ) {
+    final name = _finderName(notification);
+    final petName = report?.petName.trim().isNotEmpty == true
+        ? report!.petName.trim()
+        : notification.actionPetName.trim();
+    final petLabel = petName.isEmpty ? 'your pet' : petName;
+    return name.isEmpty ? 'Someone found $petLabel' : '$name found $petLabel';
+  }
+
+  String _finderName(NotificationModel notification) {
+    final structuredName = notification.actionReporterName.trim();
+    if (structuredName.isNotEmpty) {
+      return structuredName;
+    }
+
+    final text = notification.text.trim();
+    final match = RegExp(r'^(.*?) scanned ').firstMatch(text);
+    final name = match?.group(1)?.trim() ?? '';
+    return name == 'Someone' ? '' : name;
+  }
+}
+
+class _NotificationIconButton extends StatelessWidget {
+  const _NotificationIconButton({
+    required this.icon,
+    required this.color,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      width: 44,
+      height: 44,
+      child: IconButton(
+        onPressed: onPressed,
+        visualDensity: VisualDensity.compact,
+        padding: EdgeInsets.zero,
+        icon: Icon(icon, size: 22, color: color.withValues(alpha: 0.9)),
+      ),
+    );
+  }
+}
+
+class _NotificationActionChip extends StatelessWidget {
+  const _NotificationActionChip({
+    required this.icon,
+    required this.label,
+    required this.color,
+    required this.onPressed,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color color;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    return OutlinedButton.icon(
+      onPressed: onPressed,
+      icon: Icon(icon, size: 16),
+      label: Text(label),
+      style: OutlinedButton.styleFrom(
+        foregroundColor: color,
+        side: BorderSide(color: color.withValues(alpha: 0.56)),
+        minimumSize: const Size(0, 44),
+        visualDensity: VisualDensity.compact,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppDimensions.spaceM,
+          vertical: AppDimensions.spaceS,
+        ),
+      ),
+    );
+  }
+}
+
+class _NotificationPetPhoto extends StatelessWidget {
+  const _NotificationPetPhoto({
+    required this.notification,
+    required this.report,
+  });
+
+  final NotificationModel notification;
+  final LostPetReportModel? report;
+
+  @override
+  Widget build(BuildContext context) {
+    final reportPhotoUrl = report?.photoUrl?.trim() ?? '';
+    final photoUrl = reportPhotoUrl.isNotEmpty
+        ? reportPhotoUrl
+        : notification.actionPetPhotoUrl.trim();
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(AppDimensions.radiusM),
+      child: SizedBox(
+        width: 44,
+        height: 44,
+        child: photoUrl.isEmpty
+            ? Container(
+                color: AppColors.smartAlertInfoText.withValues(alpha: 0.16),
+                child: const Icon(
+                  Icons.pets_rounded,
+                  color: AppColors.smartAlertInfoText,
+                ),
+              )
+            : CachedNetworkImage(
+                imageUrl: photoUrl,
+                cacheManager: AppImageCacheManager.instance,
+                fit: BoxFit.cover,
+              ),
+      ),
+    );
+  }
+}
+
+class _NotificationSummary extends StatelessWidget {
+  const _NotificationSummary({
+    required this.notification,
+    required this.report,
+    required this.textColor,
+  });
+
+  final NotificationModel notification;
+  final LostPetReportModel? report;
+  final Color textColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final location = notification.actionLocation.trim().isNotEmpty
+        ? notification.actionLocation.trim()
+        : AppStrings.valueNotAvailable;
+    final petName = report?.petName.trim().isNotEmpty == true
+        ? report!.petName.trim()
+        : notification.actionPetName.trim().isNotEmpty
+        ? notification.actionPetName.trim()
+        : 'Lost pet';
+    final time = notification.dateSent == null
+        ? ''
+        : _relativeTime(notification.dateSent!);
+    final rows = [
+      _SummaryRowData(
+        icon: Icons.person_outline_rounded,
+        label: 'Finder',
+        value: _finderName(notification).isEmpty
+            ? 'Contact not shared'
+            : _finderName(notification),
+      ),
+      _SummaryRowData(
+        icon: Icons.location_on_outlined,
+        label: 'Location',
+        value: location,
+      ),
+      _SummaryRowData(icon: Icons.pets_rounded, label: 'Pet', value: petName),
+      if (time.isNotEmpty)
+        _SummaryRowData(
+          icon: Icons.access_time_rounded,
+          label: 'Time',
+          value: time,
+        ),
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        for (final row in rows) ...[
+          _NotificationSummaryRow(row: row, color: textColor),
+          const SizedBox(height: 3),
+        ],
+      ],
+    );
+  }
+
+  String _relativeTime(DateTime value) {
+    final difference = DateTime.now().difference(value.toLocal());
+    if (difference.inDays >= 1) {
+      return '${difference.inDays}d ago';
+    }
+    if (difference.inHours >= 1) {
+      return '${difference.inHours}h ago';
+    }
+    if (difference.inMinutes >= 1) {
+      return '${difference.inMinutes}m ago';
+    }
+    return 'Just now';
+  }
+
+  String _finderName(NotificationModel notification) {
+    final structuredName = notification.actionReporterName.trim();
+    if (structuredName.isNotEmpty) {
+      return structuredName;
+    }
+
+    final text = notification.text.trim();
+    final match = RegExp(r'^(.*?) scanned ').firstMatch(text);
+    final name = match?.group(1)?.trim() ?? '';
+    return name == 'Someone' ? '' : name;
+  }
+}
+
+class _SummaryRowData {
+  const _SummaryRowData({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  final IconData icon;
+  final String label;
+  final String value;
+}
+
+class _NotificationSummaryRow extends StatelessWidget {
+  const _NotificationSummaryRow({required this.row, required this.color});
+
+  final _SummaryRowData row;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Icon(row.icon, size: 15, color: color.withValues(alpha: 0.74)),
+        const SizedBox(width: AppDimensions.spaceXS),
+        Expanded(
+          child: Text.rich(
+            TextSpan(
+              children: [
+                TextSpan(
+                  text: '${row.label}: ',
+                  style: TextStyle(
+                    color: color.withValues(alpha: 0.72),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                TextSpan(
+                  text: row.value,
+                  style: TextStyle(
+                    color: color.withValues(alpha: 0.88),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+            style: Theme.of(
+              context,
+            ).textTheme.bodySmall?.copyWith(height: 1.25),
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/shared/widgets/lost_pet_map_preview.dart
+++ b/lib/shared/widgets/lost_pet_map_preview.dart
@@ -1,0 +1,266 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_map/flutter_map.dart';
+import 'package:latlong2/latlong.dart';
+
+import '../../core/constants/app_colors.dart';
+import '../../core/constants/app_dimensions.dart';
+import '../../core/services/map_tile_cache_service.dart';
+
+class LostPetMapPreview extends StatelessWidget {
+  const LostPetMapPreview({
+    super.key,
+    this.latitude,
+    this.longitude,
+    this.height = 148,
+    this.onPointSelected,
+  });
+
+  static const LatLng _bogotaCenter = LatLng(4.7110, -74.0721);
+
+  final double? latitude;
+  final double? longitude;
+  final double height;
+  final ValueChanged<LostPetMapPoint>? onPointSelected;
+
+  bool get _hasPoint => latitude != null && longitude != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final point = _hasPoint ? LatLng(latitude!, longitude!) : null;
+    final center = point ?? _bogotaCenter;
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(20),
+      child: SizedBox(
+        height: height,
+        width: double.infinity,
+        child: FlutterMap(
+          options: MapOptions(
+            initialCenter: center,
+            initialZoom: point == null ? 11 : 15,
+            minZoom: 11,
+            maxZoom: 18,
+            backgroundColor: Colors.transparent,
+            cameraConstraint: CameraConstraint.containCenter(
+              bounds: MapTileCacheService.bogotaBounds,
+            ),
+            onTap: onPointSelected == null
+                ? null
+                : (_, latLng) {
+                    onPointSelected!(
+                      LostPetMapPoint(
+                        latitude: latLng.latitude,
+                        longitude: latLng.longitude,
+                      ),
+                    );
+                  },
+          ),
+          children: [
+            const _MapFallbackBackground(),
+            TileLayer(
+              urlTemplate: MapTileCacheService.osmTileUrlTemplate,
+              userAgentPackageName: MapTileCacheService.userAgentPackageName,
+              tileProvider: NetworkTileProvider(silenceExceptions: true),
+              tileBounds: MapTileCacheService.bogotaBounds,
+              maxZoom: 18,
+              maxNativeZoom: 18,
+              panBuffer: 1,
+            ),
+            if (point != null)
+              MarkerLayer(
+                markers: [
+                  Marker(
+                    point: point,
+                    width: 48,
+                    height: 48,
+                    alignment: Alignment.topCenter,
+                    child: DecoratedBox(
+                      decoration: BoxDecoration(
+                        color: AppColors.onPrimary,
+                        shape: BoxShape.circle,
+                        boxShadow: [
+                          BoxShadow(
+                            color: Colors.black.withValues(alpha: 0.18),
+                            blurRadius: 10,
+                            offset: const Offset(0, 4),
+                          ),
+                        ],
+                      ),
+                      child: const Icon(
+                        Icons.location_on_rounded,
+                        color: AppColors.negativeText,
+                        size: 42,
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            Positioned(
+              right: AppDimensions.spaceS,
+              bottom: AppDimensions.spaceS,
+              child: _MapAttribution(isDark: isDark),
+            ),
+            if (onPointSelected != null)
+              Positioned(
+                left: AppDimensions.spaceS,
+                top: AppDimensions.spaceS,
+                child: _MapHint(isDark: isDark),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MapFallbackBackground extends StatelessWidget {
+  const _MapFallbackBackground();
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isDark ? AppColors.secondaryDark : AppColors.primaryVariant,
+      ),
+      child: Stack(
+        children: [
+          Positioned.fill(
+            child: CustomPaint(
+              painter: _MapGridPainter(
+                lineColor: (isDark ? AppColors.grey700 : AppColors.primary)
+                    .withValues(alpha: 0.12),
+              ),
+            ),
+          ),
+          Center(
+            child: DecoratedBox(
+              decoration: BoxDecoration(
+                color:
+                    (isDark
+                            ? AppColors.petCardBackgroundDark
+                            : AppColors.petCardBackground)
+                        .withValues(alpha: 0.82),
+                borderRadius: BorderRadius.circular(999),
+              ),
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 14,
+                  vertical: 8,
+                ),
+                child: Text(
+                  'Online map unavailable',
+                  style: TextStyle(
+                    color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+                    fontSize: 11,
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _MapGridPainter extends CustomPainter {
+  const _MapGridPainter({required this.lineColor});
+
+  final Color lineColor;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = lineColor
+      ..strokeWidth = 1;
+    const spacing = 28.0;
+
+    for (var x = 0.0; x <= size.width; x += spacing) {
+      canvas.drawLine(Offset(x, 0), Offset(x, size.height), paint);
+    }
+
+    for (var y = 0.0; y <= size.height; y += spacing) {
+      canvas.drawLine(Offset(0, y), Offset(size.width, y), paint);
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _MapGridPainter oldDelegate) {
+    return oldDelegate.lineColor != lineColor;
+  }
+}
+
+class LostPetMapPoint {
+  const LostPetMapPoint({required this.latitude, required this.longitude});
+
+  final double latitude;
+  final double longitude;
+}
+
+class _MapAttribution extends StatelessWidget {
+  const _MapAttribution({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color:
+            (isDark
+                    ? AppColors.petCardBackgroundDark
+                    : AppColors.petCardBackground)
+                .withValues(alpha: 0.78),
+        borderRadius: BorderRadius.circular(6),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 2),
+        child: Text(
+          '© OSM',
+          style: TextStyle(
+            color: isDark ? AppColors.onSurfaceDark : AppColors.grey700,
+            fontSize: 9,
+            fontWeight: FontWeight.w600,
+            height: 1,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _MapHint extends StatelessWidget {
+  const _MapHint({required this.isDark});
+
+  final bool isDark;
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: isDark
+            ? AppColors.petCardBackgroundDark.withValues(alpha: 0.9)
+            : AppColors.petCardBackground.withValues(alpha: 0.9),
+        borderRadius: BorderRadius.circular(999),
+        border: Border.all(
+          color: isDark ? AppColors.bottomNavTopBorderDark : AppColors.grey300,
+        ),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+        child: Text(
+          'Tap to set',
+          style: TextStyle(
+            color: isDark ? AppColors.onSurfaceDark : AppColors.onSurface,
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            height: 1,
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/shared/widgets/petcare_bottom_nav_bar.dart
+++ b/lib/shared/widgets/petcare_bottom_nav_bar.dart
@@ -26,9 +26,7 @@ class PetcareBottomNavBar extends StatelessWidget {
     return Container(
       decoration: BoxDecoration(
         color: backgroundColor,
-        border: Border(
-          top: BorderSide(color: borderColor, width: 1),
-        ),
+        border: Border(top: BorderSide(color: borderColor, width: 1)),
       ),
       child: SafeArea(
         top: false,
@@ -70,9 +68,9 @@ class _NavBarItem extends StatelessWidget {
     final isDark = Theme.of(context).brightness == Brightness.dark;
     final color = isActive
         ? AppColors.bottomNavActive
-      : (isDark
-        ? AppColors.bottomNavInactiveDark
-        : AppColors.bottomNavInactive);
+        : (isDark
+              ? AppColors.bottomNavInactiveDark
+              : AppColors.bottomNavInactive);
     final useActiveAsset = isActive && item.activeAssetPath != null;
     final assetPath = useActiveAsset ? item.activeAssetPath! : item.assetPath;
     final iconColor = useActiveAsset ? null : color;
@@ -102,10 +100,7 @@ class _NavBarItem extends StatelessWidget {
 }
 
 class _NavIcon extends StatelessWidget {
-  const _NavIcon({
-    required this.assetPath,
-    required this.color,
-  });
+  const _NavIcon({required this.assetPath, required this.color});
 
   final String assetPath;
   final Color? color;
@@ -151,11 +146,7 @@ const List<_NavItem> _navItems = [
     assetPath: 'assets/icons/featureIcons/pets.svg',
     activeAssetPath: 'assets/icons/featureIcons/petsSecondary.svg',
   ),
-  _NavItem(
-    label: 'Records',
-    assetPath: 'assets/icons/featureIcons/records.svg',
-    activeAssetPath: 'assets/icons/featureIcons/recordsSecondary.svg',
-  ),
+  _NavItem(label: 'Lost', assetPath: 'assets/icons/featureIcons/location.svg'),
   _NavItem(
     label: 'Calendar',
     assetPath: 'assets/icons/featureIcons/calendar.svg',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,9 @@ dependencies:
   shared_preferences: ^2.2.2
   sqflite: ^2.4.2
   url_launcher: ^6.3.1
+  geolocator: ^14.0.2
+  flutter_map: ^8.3.0
+  latlong2: ^0.9.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Changelog

- Added Lost Pets tab and public lost pets listing.
- Added lost pet detail screen with safe public information and owner-approved CTAs.
- Added owner Lost Mode screen to mark pets as lost/found, configure emergency contact visibility, add notes, manage NFC notifications, and set last seen location.
- Added NFC lost pet scan flow with location/contact sharing and owner scan handling.
- Added Smart Alerts support for latest lost pet sighting notifications.
- Added local cache/offline support for lost pet reports, dismissed notifications, and pending lost mode sync operations.
- Added online-only map preview with manual latitude/longitude fallback.
- Updated pet detail and pet list actions to support Lost Mode and NFC flows.

## Related Issue

Completed #123