### PR TITLE
Track vaccine alert telemetry for BQ

### DIFF
--- a/lib/core/services/telemetry_service.dart
+++ b/lib/core/services/telemetry_service.dart
@@ -199,6 +199,27 @@ class TelemetryService {
     );
   }
 
+  Future<void> logUrgentVaccineAlertViewed() async {
+    final now = DateTime.now();
+    await _logFeatureExecution(
+      featureId: featureViewUrgentVaccineAlertId,
+      startTime: now,
+      endTime: now,
+    );
+  }
+
+  Future<void> logVaccinationRecordSaved({
+    required bool isUpdate,
+    required DateTime startTime,
+    required DateTime endTime,
+  }) async {
+    await _logFeatureExecution(
+      featureId: isUpdate ? featureEditVaccinationId : featureAddVaccinationId,
+      startTime: startTime,
+      endTime: endTime,
+    );
+  }
+
   Future<String?> _getUserId() async {
     final cached = _cachedUserId;
     if (cached != null && cached.isNotEmpty) {

--- a/lib/core/telemetry/telemetry_ids.dart
+++ b/lib/core/telemetry/telemetry_ids.dart
@@ -7,3 +7,7 @@ const String featureRouteAddEventId = '69bc1d2f2fb48df4a28aaf0a';
 const String featureVaccineAttachmentUploadId = '69eb92ef4e5c181e934ea67f';
 const String featureEventAttachmentUploadId = '69eb93064e5c181e934ea680';
 const String featureLoadCachedPetProfileId = '69eb8daba8c0fdbb7a4bde54';
+
+const String featureViewUrgentVaccineAlertId = '6a10e1d73d4e81d404b4f812';
+const String featureAddVaccinationId = '6a10e1d73d4e81d404b4f813';
+const String featureEditVaccinationId = '6a10e1d73d4e81d404b4f814';

--- a/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
+++ b/lib/presentation/pages/add_vaccine/add_vaccine_page.dart
@@ -10,6 +10,7 @@ import 'package:flutter_frontend/core/models/pet_model.dart';
 import 'package:flutter_frontend/core/models/vaccine_model.dart';
 import 'package:flutter_frontend/core/services/attachment_upload_coordinator.dart';
 import 'package:flutter_frontend/core/services/pet_service.dart';
+import 'package:flutter_frontend/core/services/telemetry_service.dart';
 import 'package:flutter_frontend/core/services/vaccine_service.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:flutter_frontend/presentation/pages/add_flow/utils/date_input.dart';
@@ -40,6 +41,7 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
   final VaccineService _vaccineService = VaccineService();
   final PetService _petService = PetService();
+  final TelemetryService _telemetryService = TelemetryService();
   final AttachmentUploadCoordinator _attachmentUploadCoordinator =
       AttachmentUploadCoordinator();
   final ImagePicker _imagePicker = ImagePicker();
@@ -323,7 +325,6 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
     final name = _normalizeDropdownValue(prefill.vaccineName);
     if (name != null) {
-
       final firstMatch = _vaccines.firstWhere(
         (vaccine) => vaccine.name == name,
         orElse: () => const VaccineModel(id: '', schema: '', name: ''),
@@ -439,9 +440,11 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
   List<VaccineModel> get _visibleVaccines {
     final vaccines = _vaccines
         .where(_isVaccineAllowedForSelectedPet)
-        .where((vaccine) =>
-            vaccine.name.trim().isNotEmpty &&
-            vaccine.name.trim() != AppStrings.valueNotAvailable)
+        .where(
+          (vaccine) =>
+              vaccine.name.trim().isNotEmpty &&
+              vaccine.name.trim() != AppStrings.valueNotAvailable,
+        )
         .toList(growable: false);
 
     vaccines.sort((left, right) {
@@ -480,8 +483,10 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
     final products = _visibleVaccines
         .where((vaccine) => vaccine.name == _selectedVaccineName)
         .map((vaccine) => vaccine.productName.trim())
-      .where((product) =>
-        product.isNotEmpty && product != AppStrings.valueNotAvailable)
+        .where(
+          (product) =>
+              product.isNotEmpty && product != AppStrings.valueNotAvailable,
+        )
         .toSet()
         .toList();
     products.sort();
@@ -491,7 +496,9 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
   List<String> get _petNameOptions {
     final names = _pets
         .map((pet) => pet.name.trim())
-      .where((name) => name.isNotEmpty && name != AppStrings.valueNotAvailable)
+        .where(
+          (name) => name.isNotEmpty && name != AppStrings.valueNotAvailable,
+        )
         .toSet()
         .toList();
     final selectedName = _selectedPetName?.trim() ?? '';
@@ -647,6 +654,8 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
 
   Future<void> _submitToApi(DateTime dateGiven) async {
     setState(() => _isSubmitting = true);
+    final telemetryStartTime = DateTime.now();
+    final wasEditingVaccination = _isEditingVaccination;
 
     try {
       if (_isEditingVaccination &&
@@ -705,6 +714,14 @@ class _AddVaccinePageState extends State<AddVaccinePage> {
           data: payload,
         );
       }
+
+      unawaited(
+        _telemetryService.logVaccinationRecordSaved(
+          isUpdate: wasEditingVaccination,
+          startTime: telemetryStartTime,
+          endTime: DateTime.now(),
+        ),
+      );
 
       if (!mounted) return;
       Navigator.pop(context, true);

--- a/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
+++ b/lib/presentation/pages/smart_alerts/smart_alerts_page.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -18,6 +20,7 @@ import '../../../core/services/pet_service.dart';
 import '../../../core/services/connectivity_sync_service.dart';
 import '../../../core/services/notification_service.dart';
 import '../../../core/services/smart_feature_service.dart';
+import '../../../core/services/telemetry_service.dart';
 import '../lost_pets/lost_pet_sighting_detail_page.dart';
 import '../../../shared/widgets/smart_alert_card.dart';
 
@@ -36,12 +39,14 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
   final NotificationService _notificationService = NotificationService();
   final LostPetService _lostPetService = LostPetService();
   final AppPreferencesService _preferencesService = AppPreferencesService();
+  final TelemetryService _telemetryService = TelemetryService();
 
   List<PetModel> _pets = const [];
   List<SmartAlertItem> _alerts = const [];
   List<NotificationModel> _notifications = const [];
   Map<String, LostPetReportModel> _lostPetReportsByReportId = const {};
   final Set<String> _dismissedNotificationIds = <String>{};
+  final Set<String> _loggedUrgentVaccineAlertKeys = <String>{};
   String? _selectedPetId;
   bool _isLoading = false;
   String? _errorMessage;
@@ -132,6 +137,7 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
             ? normalizedSelection
             : null;
       });
+      _logUrgentVaccineAlertsViewed(alerts);
     } on ApiException catch (error) {
       if (!mounted) {
         return;
@@ -210,6 +216,38 @@ class _SmartAlertsPageState extends State<SmartAlertsPage> {
 
   int _countForPet(String petId) {
     return _alerts.where((item) => item.petId == petId).length;
+  }
+
+  void _logUrgentVaccineAlertsViewed(List<SmartAlertItem> alerts) {
+    for (final alert in alerts) {
+      if (!_isUrgentVaccineAlert(alert)) {
+        continue;
+      }
+
+      final key = [
+        alert.petId,
+        alert.suggestion.title,
+        alert.suggestion.message,
+      ].join('|');
+      if (!_loggedUrgentVaccineAlertKeys.add(key)) {
+        continue;
+      }
+
+      unawaited(_telemetryService.logUrgentVaccineAlertViewed());
+    }
+  }
+
+  bool _isUrgentVaccineAlert(SmartAlertItem alert) {
+    final title = alert.suggestion.title.toLowerCase();
+    final message = alert.suggestion.message.toLowerCase();
+    final text = '$title $message';
+    final isVaccineAlert =
+        text.contains('vaccine') || text.contains('vaccination');
+    final isUrgent =
+        text.contains('overdue') ||
+        text.contains('expired') ||
+        text.contains('missing');
+    return isVaccineAlert && isUrgent;
   }
 
   Future<void> _dismissNotification(NotificationModel notification) async {


### PR DESCRIPTION
## Summary
- Add Flutter telemetry IDs for the vaccine alerts Type 5 BQ.
- Track urgent vaccine alert views from Smart Alerts.
- Track successful vaccination record creation and edits after backend persistence.

## Business logic
- Urgent vaccine alert views are logged only for Smart Alerts whose title/message mention vaccine or vaccination and indicate an urgent state: missing, overdue, or expired.
- Alert view telemetry is deduplicated per page session by pet, title, and message to avoid repeated logs during local UI refreshes.
- Add/edit vaccination telemetry is emitted only after the vaccination API call succeeds.
- The frontend uses fixed Feature IDs already present in Mongo; no backend API or Kotlin client changes are required.

## Validation
- Verified on Android emulator against local backend.
- Confirmed FeatureExecutionLog rows are persisted in Mongo for urgent alert views, vaccine creation, and vaccine edit.
- Ran dart format.
- Ran flutter analyze; remaining findings are pre-existing issues outside this change.

Closes #128